### PR TITLE
add zkSync Era bridge adapter

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,6 +66,7 @@ provider:
     OPTIMISM_RPC: ${env:OPTIMISM_RPC}
     AURORA_RPC: ${env:AURORA_RPC}
     ARBITRUM_RPC: ${env:ARBITRUM_RPC}
+    ZKSYNC_RPC: ${env:ZKSYNC_RPC}
 
 functions:
   bridgeDayStats:

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -25,6 +25,7 @@ import ibc from "./ibc";
 import meter from "./meter";
 // import tronpeg from "./tronpeg"
 import beamer from "./beamer";
+import zksync from "./zksync";
 
 export default {
   polygon,
@@ -52,6 +53,7 @@ export default {
   ibc,
   meter,
   beamer,
+  zksync,
 } as {
   [bridge: string]: BridgeAdapter;
 };

--- a/src/adapters/zksync/index.ts
+++ b/src/adapters/zksync/index.ts
@@ -18,6 +18,39 @@ import { constructTransferParams } from "../../helpers/eventParams";
 
 const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
+const ethDepositEventParams: PartialContractEventParams = {
+    target: "0x32400084C286CF3E17e7B677ea9583e60a000324",
+    // topic: "NewPriorityRequest(uint256,bytes32,uint64,tuple,bytes[])", // as shown on Etherscan
+    topic: "NewPriorityRequest(uint256,bytes32,uint64,tuple(uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes),bytes[])", // expand tuple data types
+    // topic: "NewPriorityRequest(uint256,bytes32,uint64,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256,uint256[4],bytes,bytes,uint256[],bytes,bytes,bytes[])", // break out data types from tuple
+    abi: [
+        // "event NewPriorityRequest(uint256 txId, bytes32 txHash, uint64 expirationTimestamp, tuple transaction, bytes[] factoryDeps)", // as shown on Etherscan
+        "event NewPriorityRequest(uint256 txId, bytes32 txHash, uint64 expirationTimestamp, tuple(uint256 txType, uint256 from, uint256 to, uint256 gasLimit, uint256 gasPerPubdataByteLimit, uint256 maxFeePerGas, uint256 maxPriorityFeePerGas, uint256 paymaster, uint256 nonce, uint256 value, uint256[4] reserved, bytes data, bytes signature, uint256[] factoryDeps, bytes paymasterInput, bytes reservedDynamic) transaction, bytes[] factoryDeps)",
+    ],
+    logKeys: {
+        txHash: 'txHash',
+    },
+    argKeys: {
+        to: "to",
+        amount: "value",
+    },
+    fixedEventData: {
+        from: "0x32400084C286CF3E17e7B677ea9583e60a000324",
+        token: WETH,
+    },
+    // inputDataExtraction: {
+    //     inputDataABI: [
+    //     "function requestL2Transaction(address _contractL2,uint256 _l2Value,bytes _calldata,uint256 _l2GasLimit,uint256 _l2GasPerPubdataByteLimit,bytes[] _factoryDeps,address _refundRecipient)",
+    //     ],
+    //     inputDataFnName: "requestL2Transaction",
+    //     inputDataKeys: {
+    //         from: "_contractL2",
+    //         amount: "_l2Value",
+    //     },
+    // },
+  isDeposit: true,
+};
+
 const erc20DepositEventParams: PartialContractEventParams =
   constructTransferParams(
     "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
@@ -49,10 +82,10 @@ const erc20WithdrawalEventParams: PartialContractEventParams =
 
 const constructParams = () => {
 const eventParams = [
-    // ethDepositEventParams,
-    erc20DepositEventParams,
-    ethWithdrawalEventParams,
-    erc20WithdrawalEventParams,
+    ethDepositEventParams,
+    // erc20DepositEventParams,
+    // ethWithdrawalEventParams,
+    // erc20WithdrawalEventParams,
 ];
 return async (fromBlock: number, toBlock: number) =>
     getTxDataFromEVMEventLogs("zksync", "ethereum", fromBlock, toBlock, eventParams);

--- a/src/adapters/zksync/index.ts
+++ b/src/adapters/zksync/index.ts
@@ -1,4 +1,4 @@
-import { BridgeAdapter, PartialContractEventParams, ContractEventParams } from "../../helpers/bridgeAdapter.type";
+import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 import { constructTransferParams } from "../../helpers/eventParams";
 
@@ -16,11 +16,30 @@ import { constructTransferParams } from "../../helpers/eventParams";
         - ERC20
 */
 
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
 const erc20DepositEventParams: PartialContractEventParams =
   constructTransferParams(
     "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
     true
 );
+
+const ethWithdrawalEventParams: PartialContractEventParams = {
+    target: "0x32400084C286CF3E17e7B677ea9583e60a000324",
+    topic: "EthWithdrawalFinalized(address,uint256)",
+    abi: [
+        "event EthWithdrawalFinalized(address indexed to, uint256 amount)",
+    ],
+    argKeys: {
+        to: "to",
+        amount: "amount",
+    },
+    fixedEventData: {
+        from: "0x32400084C286CF3E17e7B677ea9583e60a000324",
+        token: WETH,
+    },
+    isDeposit: false,
+};
 
 const erc20WithdrawalEventParams: PartialContractEventParams =
   constructTransferParams(
@@ -30,7 +49,9 @@ const erc20WithdrawalEventParams: PartialContractEventParams =
 
 const constructParams = () => {
 const eventParams = [
+    // ethDepositEventParams,
     erc20DepositEventParams,
+    ethWithdrawalEventParams,
     erc20WithdrawalEventParams,
 ];
 return async (fromBlock: number, toBlock: number) =>

--- a/src/adapters/zksync/index.ts
+++ b/src/adapters/zksync/index.ts
@@ -1,82 +1,36 @@
-import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
+import { BridgeAdapter, PartialContractEventParams, ContractEventParams } from "../../helpers/bridgeAdapter.type";
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 import { constructTransferParams } from "../../helpers/eventParams";
 
 /* 
 
 0x32400084C286CF3E17e7B677ea9583e60a000324 is zkSync Era: Diamond Proxy
+    - deposits of 
+        - ETH
 0xf8A16864D8De145A266a534174305f881ee2315e is zkSync Era: Withdrawal Finalizer
 0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063 is zkSync Era: Bridge
+    - deposits of 
+        - ERC20
+    - withdrawals of 
+        - ETH
+        - ERC20
 */
 
-const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const erc20DepositEventParams: PartialContractEventParams =
+  constructTransferParams(
+    "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
+    true
+);
 
-const ethDepositEventParams: PartialContractEventParams = {
-    target: "0x32400084C286CF3E17e7B677ea9583e60a000324",
-    topic: "NewPriorityRequest(uint256,bytes32,uint64,tuple,bytes[]",
-    abi: [
-      "event NewPriorityRequest(uint256 txId, bytes32 txHash, uint64 expirationTimestamp, tuple transaction, bytes[] factoryDeps)",
-    ],
-    argKeys: {
-      from: "transaction.from",
-      amount: "transaction.value",
-    },
-    fixedEventData: {
-        token: WETH,
-    },
-    isDeposit: true,
-};
-
-const erc20DepositEventParams: PartialContractEventParams = {
-    target: "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
-    topic: "DepositInitiated(bytes32,address,address,address,uint256",
-    abi: [
-      "event DepositInitiated(index_topic_1 bytes32 l2DepositTxHash, index_topic_2 address from, index_topic_3 address to, address l1Token, uint256 amount)",
-    ],
-    argKeys: {
-      token: "l1Token",
-      from: "from",
-      amount: "amount",
-    },
-    isDeposit: true,
-};
-
-const ethWithdrawalEventParams: PartialContractEventParams = {
-    target: "0xf8A16864D8De145A266a534174305f881ee2315e",
-    topic: "EthWithdrawalFinalized(address,uint256)",
-    abi: [
-        "event EthWithdrawalFinalized(index_topic_1 address to, uint256 amount)",
-    ],
-    argKeys: {
-        to: "to",
-        amount: "amount",
-    },
-    fixedEventData: {
-        token: WETH,
-    },
-    isDeposit: false,
-};
-
-const erc20WithdrawalEventParams: PartialContractEventParams = {
-    target: "0x57891966931eb4bb6fb81430e6ce0a03aabde063",
-    topic: "WithdrawalFinalized(address,address,uint256)",
-    abi: [
-        "event WithdrawalFinalized(index_topic_1 address to, index_topic_2 address l1Token, uint256 amount)",
-    ],
-    argKeys: {
-        token: "l1Token",
-        to: "to",
-        amount: "amount",
-    },
-    isDeposit: false,
-};
-
+const erc20WithdrawalEventParams: PartialContractEventParams =
+  constructTransferParams(
+    "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
+    false
+);
 
 const constructParams = () => {
 const eventParams = [
-    ethDepositEventParams,
     erc20DepositEventParams,
-    ethWithdrawalEventParams,
     erc20WithdrawalEventParams,
 ];
 return async (fromBlock: number, toBlock: number) =>
@@ -84,7 +38,7 @@ return async (fromBlock: number, toBlock: number) =>
 };
 
 const adapter: BridgeAdapter = {
-ethereum: constructParams(),
+    ethereum: constructParams(),
 };
-
+  
 export default adapter;

--- a/src/adapters/zksync/index.ts
+++ b/src/adapters/zksync/index.ts
@@ -1,0 +1,90 @@
+import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
+import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
+import { constructTransferParams } from "../../helpers/eventParams";
+
+/* 
+
+0x32400084C286CF3E17e7B677ea9583e60a000324 is zkSync Era: Diamond Proxy
+0xf8A16864D8De145A266a534174305f881ee2315e is zkSync Era: Withdrawal Finalizer
+0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063 is zkSync Era: Bridge
+*/
+
+const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+const ethDepositEventParams: PartialContractEventParams = {
+    target: "0x32400084C286CF3E17e7B677ea9583e60a000324",
+    topic: "NewPriorityRequest(uint256,bytes32,uint64,tuple,bytes[]",
+    abi: [
+      "event NewPriorityRequest(uint256 txId, bytes32 txHash, uint64 expirationTimestamp, tuple transaction, bytes[] factoryDeps)",
+    ],
+    argKeys: {
+      from: "transaction.from",
+      amount: "transaction.value",
+    },
+    fixedEventData: {
+        token: WETH,
+    },
+    isDeposit: true,
+};
+
+const erc20DepositEventParams: PartialContractEventParams = {
+    target: "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
+    topic: "DepositInitiated(bytes32,address,address,address,uint256",
+    abi: [
+      "event DepositInitiated(index_topic_1 bytes32 l2DepositTxHash, index_topic_2 address from, index_topic_3 address to, address l1Token, uint256 amount)",
+    ],
+    argKeys: {
+      token: "l1Token",
+      from: "from",
+      amount: "amount",
+    },
+    isDeposit: true,
+};
+
+const ethWithdrawalEventParams: PartialContractEventParams = {
+    target: "0xf8A16864D8De145A266a534174305f881ee2315e",
+    topic: "EthWithdrawalFinalized(address,uint256)",
+    abi: [
+        "event EthWithdrawalFinalized(index_topic_1 address to, uint256 amount)",
+    ],
+    argKeys: {
+        to: "to",
+        amount: "amount",
+    },
+    fixedEventData: {
+        token: WETH,
+    },
+    isDeposit: false,
+};
+
+const erc20WithdrawalEventParams: PartialContractEventParams = {
+    target: "0x57891966931eb4bb6fb81430e6ce0a03aabde063",
+    topic: "WithdrawalFinalized(address,address,uint256)",
+    abi: [
+        "event WithdrawalFinalized(index_topic_1 address to, index_topic_2 address l1Token, uint256 amount)",
+    ],
+    argKeys: {
+        token: "l1Token",
+        to: "to",
+        amount: "amount",
+    },
+    isDeposit: false,
+};
+
+
+const constructParams = () => {
+const eventParams = [
+    ethDepositEventParams,
+    erc20DepositEventParams,
+    ethWithdrawalEventParams,
+    erc20WithdrawalEventParams,
+];
+return async (fromBlock: number, toBlock: number) =>
+    getTxDataFromEVMEventLogs("zksync", "ethereum", fromBlock, toBlock, eventParams);
+};
+
+const adapter: BridgeAdapter = {
+ethereum: constructParams(),
+};
+
+export default adapter;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -369,4 +369,14 @@ export default [
   //   url: "",
   //   chains: ["Ethereum", "Arbitrum", "Optimism"]
   // },
+  {
+    id: 26,
+    displayName: "zkSync Era Bridge",
+    bridgeDbName: "zksync",
+    iconLink: "chain:zksync",
+    largeTxThreshold: 10000,
+    url: "",
+    chains: ["Ethereum", "zkSync"],
+    destinationChain: "zkSync",
+  },
 ] as BridgeNetwork[];


### PR DESCRIPTION
This PR:

- Adds a zkSync Era bridge adapter
- Covers the native zkSync bridge (no custom bridges)

I think `erc20DepositEventParams`, `ethWithdrawalEventParams`, and `erc20WithdrawalEventParams` will all work , but I haven't figured out how to test it yet. I am less confident with `ethDepositEventParams` because of the format to pass values to `argKeys`. The structure of the transaction tuple can be found [here](https://github.com/matter-labs/v2-testnet-contracts/blob/b8449bf9c819098cc8bfee0549ff5094456be51d/l1/contracts/zksync/facets/Mailbox.sol#L298).