### PR TITLE
feat: Add zkSync and Base to Across adapter

### DIFF
--- a/src/adapters/across/index.ts
+++ b/src/adapters/across/index.ts
@@ -27,6 +27,12 @@ const contracts = {
   optimism: {
     spokePoolv2: "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
     spokePoolv2p5: "0x6f26Bf09B1C792e3228e5467807a900A503c0281"
+  },
+  era: {
+    spokePoolv2p5: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF"
+  },
+  base: {
+    spokePoolv2p5: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64"
   }
 } as const;
 
@@ -111,34 +117,39 @@ const relaysParamsv2: PartialContractEventParams = {
 };
 
 const constructParams = (chain: SupportedChains) => {
-  // New Spoke Pools
-  const finalDepositParamsv2p5 = {
-    ...depositParamsv2p5,
-    target: contracts[chain].spokePoolv2p5,
-  };
+  const eventParams: PartialContractEventParams[] = [];
 
-  const finalRelaysParamsv2p5 = {
-    ...relaysParamsv2p5,
-    target: contracts[chain].spokePoolv2p5,
-  };
+  const chainConfig = contracts[chain]
 
   // Old Spoke Pools
-  const finalDepositParamsv2 = {
-    ...depositParamsv2,
-    target: contracts[chain].spokePoolv2,
-  };
+  if ("spokePoolv2" in chainConfig) {
+    const finalDepositParamsv2 = {
+      ...depositParamsv2,
+      target: chainConfig.spokePoolv2,
+    };
+    eventParams.push(finalDepositParamsv2);
 
-  const finalRelaysParamsv2 = {
-    ...relaysParamsv2,
-    target: contracts[chain].spokePoolv2,
-  };
+    const finalRelaysParamsv2 = {
+      ...relaysParamsv2,
+      target: chainConfig.spokePoolv2,
+    };
+    eventParams.push(finalRelaysParamsv2);
+  }
 
-  const eventParams = [
-    finalDepositParamsv2p5,
-    finalRelaysParamsv2p5,
-    finalDepositParamsv2,
-    finalRelaysParamsv2,
-  ]
+  // New Spoke Pools
+  if ("spokePoolv2p5" in chainConfig) {
+    const finalDepositParamsv2p5 = {
+      ...depositParamsv2p5,
+      target: chainConfig.spokePoolv2p5,
+    };
+    eventParams.push(finalDepositParamsv2p5);
+
+    const finalRelaysParamsv2p5 = {
+      ...relaysParamsv2p5,
+      target: chainConfig.spokePoolv2p5,
+    };
+    eventParams.push(finalRelaysParamsv2p5);
+  }
 
   return async (fromBlock: number, toBlock: number) =>
     getTxDataFromEVMEventLogs("across", chain, fromBlock, toBlock, eventParams);
@@ -149,6 +160,8 @@ const adapter: BridgeAdapter = {
   polygon: constructParams("polygon"),
   arbitrum: constructParams("arbitrum"),
   optimism: constructParams("optimism"),
+  era: constructParams("era"),
+  base: constructParams("base"),
 };
 
 export default adapter;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -294,7 +294,7 @@ export default [
     iconLink: "icons:across",
     largeTxThreshold: 10000,
     url: "",
-    chains: ["Ethereum", "Polygon", "Arbitrum", "Optimism"],
+    chains: ["Ethereum", "Polygon", "Arbitrum", "Optimism", "zkSync Era"],
   },
   /*
   {


### PR DESCRIPTION
Across added support for ZkSync last week and Base support will be released in the next 1-2 weeks (note, the Base contract is already live and hypothetically could be used but we're still doing internal testing before posting in on the FE).

This PR reflects these updates to the DefiLlama bridge dashboard.