### PR TITLE
Portal (Wormhole) bridge adapter rework and fixes

### DIFF
--- a/src/adapters/portal/index.ts
+++ b/src/adapters/portal/index.ts
@@ -1,77 +1,88 @@
 import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
 import { Chain } from "@defillama/sdk/build/general";
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
-import { constructTransferParams } from "../../helpers/eventParams";
 import { getTxsBlockRangeEtherscan, getLock } from "../../helpers/etherscan";
 import { EventData } from "../../utils/types";
 import { getProvider } from "@defillama/sdk/build/general";
 import { ethers } from "ethers";
-import { PromisePool } from '@supercharge/promise-pool'
+import { PromisePool } from "@supercharge/promise-pool";
 
-// Wormhole: Portal token bridge contract addresses
+// Wormhole: Portal core and token bridge contract addresses
 // https://docs.wormhole.com/wormhole/blockchain-environments/environments
 const contractAddresses = {
   ethereum: {
     tokenBridge: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
-    nativeToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    coreBridge: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B",
   },
   polygon: {
     tokenBridge: "0x5a58505a96D1dbf8dF91cB21B54419FC36e93fdE",
-    nativeToken: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+    coreBridge: "0x7A4B5a56256163F07b2C80A7cA55aBE66c4ec4d7",
   },
   fantom: {
     tokenBridge: "0x7C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2",
-    nativeToken: "0x21be370D5312f44cB42ce377BC9b8a0cEF1A4C83",
+    coreBridge: "0x126783A6Cb203a3E35344528B26ca3a0489a1485",
   },
   avax: {
     tokenBridge: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
-    nativeToken: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+    coreBridge: "0x54a8e5f9c4CbA08F9943965859F6c34eAF03E26c",
   },
   bsc: {
     tokenBridge: "0xB6F6D86a8f9879A9c87f643768d9efc38c1Da6E7",
-    nativeToken: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+    coreBridge: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B",
   },
   aurora: {
     tokenBridge: "0x51b5123a7b0F9b2bA265f9c4C8de7D78D52f510F",
-    nativeToken: "0xC9BdeEd33CD01541e1eeD10f90519d2C06Fe3feB",
+    coreBridge: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E",
   },
   celo: {
     tokenBridge: "0x796Dff6D74F3E27060B71255Fe517BFb23C93eed",
-    nativeToken: "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    coreBridge: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E",
   },
   klaytn: {
     tokenBridge: "0x5b08ac39EAED75c0439FC750d9FE7E1F9dD0193F",
-    nativeToken: "0xe4f05a66ec68b54a58b17c22107b02e0232cc817",
+    coreBridge: "0x0C21603c4f3a6387e241c0091A7EA39E43E90bb7",
   },
   moonbeam: {
     tokenBridge: "0xb1731c586ca89a23809861c6103f0b96b3f57d92",
-    nativeToken: "0xAcc15dC74880C9944775448304B263D191c6077F",
+    coreBridge: "0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3",
   },
   optimism: {
     tokenBridge: "0x1D68124e65faFC907325e3EDbF8c4d84499DAa8b",
-    nativeToken: "0x4200000000000000000000000000000000000006",
+    coreBridge: "0xEe91C335eab126dF5fDB3797EA9d6aD93aeC9722",
   },
   arbitrum: {
     tokenBridge: "0x0b2402144Bb366A632D14B83F244D2e0e21bD39c",
-    nativeToken: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+    coreBridge: "0xa5f208e072434bC67592E4C49C1B991BA79BCA46",
   },
   base: {
     tokenBridge: "0x8d2de8d2f73F1F4cAB472AC9A881C9b123C79627",
-    nativeToken: "0x4200000000000000000000000000000000000006",
+    coreBridge: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6",
   },
 } as {
   [chain: string]: {
     tokenBridge: string;
-    nativeToken: string;
+    coreBridge: string;
   };
 };
 
-const nativeAndWrappedTokenTransferSignatures = [
-  "0x998150", // native token xfers
-  "0xff200c",
-  "0xc68785", // wrapped token xfers
-  "0x0f5287",
-];
+const completeTransferSigs = [
+  ethers.utils.id("completeTransferAndUnwrapETH(bytes)"),
+  ethers.utils.id("completeTransferAndUnwrapETHWithPayload(bytes)"),
+  ethers.utils.id("completeTransfer(bytes)"),
+  ethers.utils.id("completeTransferWithPayload(bytes)"),
+].map((s) => s.slice(0, 8));
+
+const logMessagePublishedAbi =
+  "event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel)";
+const logMessagePublishedIface = new ethers.utils.Interface([logMessagePublishedAbi]);
+const approvalIface = new ethers.utils.Interface([
+  "event Approval(address indexed owner, address indexed spender, uint256 value)",
+]);
+const transferIface = new ethers.utils.Interface([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
+const depositIface = new ethers.utils.Interface(["event Deposit(address indexed dst, uint256 wad)"]);
+const withdrawalIface = new ethers.utils.Interface(["event Withdrawal(address indexed src, uint256 wad)"]);
 
 const depositInputDataExtraction = {
   inputDataABI: [
@@ -87,135 +98,125 @@ const nativeDepositInputDataExtraction = {
   inputDataFnName: "wrapAndTransferETH",
 };
 
-const portalNativeAndWrappedTransfersFromHashes = async (
-  chain: Chain,
-  hashes: string[],
-  address: string,
-  nativeToken: string
-) => {
-  const provider = getProvider(chain) as any;
-
-  const { results, errors } = await PromisePool
-  .withConcurrency(20)
-  .for(hashes)
-  .process(async (hash) => {
-        // TODO: add timeout
-        const tx = await provider.getTransaction(hash);
-        const receipt = await provider.getTransactionReceipt(hash);
-        if (!tx) {
-          console.error(`WARNING: Unable to get transaction data on chain ${chain}, SKIPPING tx.`);
-          return;
-        }
-        if (!receipt) {
-          console.error(`WARNING: Unable to get transaction data on chain ${chain}, SKIPPING tx.`);
-          return;
-        }
-        const functionSignature = tx.data.slice(0, 8);
-        let isDeposit, token, value;
-        let { blockNumber, from, to } = tx;
-        // ***NATIVE TOKENS***
-        // if it is a deposit, can directly get all needed info from tx
-        if (functionSignature === "0x998150") {
-          if (!(address === from || address === to)) {
-            console.error(
-              `WARNING: Address given for native transfer on chain ${chain} not present in tx, SKIPPING tx.`
-            );
-            return;
-          }
-          token = nativeToken;
-          value = tx.value;
-          isDeposit = true;
-        }
-        // if it is a withdrawal, attempts to get total amount of WETH sent to contract for withdrawal
-        else if (functionSignature === "0xff200c") {
-          const logs = receipt.logs;
-          const filteredLogs = logs.filter((log: any) => {
-            const topics = log.topics;
-            const address = log.address;
-            let isTransfer = false;
-            topics.map((topic: string) => {
-              if (topic.slice(0, 8) === "0x7fcf53" && address === nativeToken) {
-                // this is sig for WETH withdrawal fn
-                isTransfer = true;
-              }
-            });
-            return isTransfer;
-          });
-          if (filteredLogs.length === 0) {
-            // console.error(`Warning: Transaction receipt on chain ${chain} contained no token transfers, SKIPPING tx.`);
-            return;
-          } else {
-            let bnAmountSum = ethers.BigNumber.from(0);
-            for (const log of filteredLogs) {
-              const value = ethers.BigNumber.from(log.data);
-              bnAmountSum = bnAmountSum.add(value);
-            }
-            token = nativeToken;
-            value = bnAmountSum;
-            isDeposit = false;
-            // switch "from" and "to" when it is a withdrawal
-            const a = from;
-            from = to;
-            to = a;
-          }
-        }
-        // ***WRAPPED TOKENS***
-        // if it is a deposit, it is already caught by 'depositEventParams'
-        // if it is a withdrawal, attempt to get the token minted from tx receipt
-        else if (functionSignature === "0xc68785") {
-          const logs = receipt.logs;
-          const filteredLogs = logs.filter((log: any) => {
-            const topics = log.topics;
-            let isTransfer = false;
-            topics.map((topic: string) => {
-              if (topic.slice(0, 8) === "0xddf252") {
-                isTransfer = true;
-              }
-            });
-            return isTransfer;
-          });
-          if (filteredLogs.length === 0) {
-            // console.error(`Warning: Transaction receipt on chain ${chain} contained no token transfers, SKIPPING tx.`);
-          } else {
-            const firstLog = filteredLogs[0];
-            const address = firstLog.address;
-            let bnAmount = ethers.BigNumber.from(0);
-            for (const log of filteredLogs) {
-              if (address === log.address) {
-                bnAmount = bnAmount.add(ethers.BigNumber.from(log.data));
-              }
-            }
-            token = address;
-            value = bnAmount;
-            isDeposit = false;
-          }
-          if (filteredLogs.length > 1) {
-            // console.error(`Warning: Transaction receipt on chain ${chain} contained multiple token transfers.`);
-          }
-          // switch "from" and "to" when it is a withdrawal
-          const a = from;
-          from = to;
-          to = a;
-        }
-        // this could be a deposit tx already covered, or a reverted tx
-        if (!token) {
-          return null;
-        }
-
-        return {
-          blockNumber: blockNumber,
-          txHash: hash,
-          from: from,
-          to: to,
-          token: token,
-          amount: value,
-          isDeposit: isDeposit,
-        } as EventData;
-      })
-  if(errors.length>0){
-    console.error("Errors in Portal's portalNativeAndWrappedTransfersFromHashes", errors)
+const tryParseLog = (log: ethers.providers.Log, parser: ethers.utils.Interface) => {
+  if (!log) return null;
+  try {
+    return parser.parseLog(log);
+  } catch {
+    return null;
   }
-  return results.filter((tx) => tx) as EventData[];
+};
+
+const portalNativeAndWrappedTransfersFromHashes = async (chain: Chain, hashes: string[], tokenBridge: string) => {
+  const provider = getProvider(chain);
+
+  const { results, errors } = await PromisePool.withConcurrency(20)
+    .for(hashes)
+    .process(async (hash) => {
+      // TODO: add timeout
+      const tx = await provider.getTransaction(hash);
+      const receipt = await provider.getTransactionReceipt(hash);
+      if (!tx || !tx.blockNumber || !receipt) {
+        console.error(`WARNING: Unable to get transaction data on chain ${chain}, SKIPPING tx.`);
+        return;
+      }
+      // make sure that the logs are sorted in ascending order
+      const logs = receipt.logs.sort((a, b) => a.logIndex - b.logIndex);
+      const results = logs.reduce((results, log, i) => {
+        let amount: ethers.BigNumber | undefined;
+        // for deposits there will be a `LogMessagePublished` event
+        const logMessagePublished = tryParseLog(log, logMessagePublishedIface);
+        if (logMessagePublished) {
+          // only care about token transfer message types (payload ID = 1 or 3)
+          const payloadID = parseInt(logMessagePublished.args.payload.slice(0, 4));
+          if (!(payloadID === 1 || payloadID === 3)) {
+            return results;
+          }
+          // the `Transfer` event will precede the `LogMessagePublished` event
+          // some token implementations may also emit an `Approval` event
+          // See https://docs.openzeppelin.com/contracts/2.x/api/token/erc20#ERC20-transferFrom-address-address-uint256-
+          let previousLog = logs[i - 1];
+          if (tryParseLog(previousLog, approvalIface)) {
+            previousLog = logs[i - 2];
+          }
+          const transfer = tryParseLog(previousLog, transferIface);
+          // lock or burn
+          if (transfer && (transfer.args.to === tokenBridge || transfer.args.to === ethers.constants.AddressZero)) {
+            amount = transfer.args.value;
+          } else {
+            const deposit = tryParseLog(previousLog, depositIface);
+            // lock
+            if (deposit && deposit.args.dst === tokenBridge) {
+              amount = deposit.args.wad;
+            }
+          }
+          if (amount) {
+            results.push({
+              blockNumber: tx.blockNumber!,
+              txHash: hash,
+              from: tx.from,
+              to: tx.to || "",
+              token: previousLog.address,
+              amount,
+              isDeposit: true,
+            });
+            return results;
+          }
+        }
+        // TODO: change this if the token bridge is upgraded to emit a `TransferRedeemed` event
+        const functionSignature = tx.data.slice(0, 8);
+        if (completeTransferSigs.includes(functionSignature)) {
+          const transfer = tryParseLog(log, transferIface);
+          // unlock or mint
+          if (transfer && (transfer.args.from === tokenBridge || transfer.args.from === ethers.constants.AddressZero)) {
+            amount = transfer.args.value;
+          } else {
+            const withdrawal = tryParseLog(log, withdrawalIface);
+            // unlock
+            if (withdrawal && withdrawal.args.src === tokenBridge) {
+              amount = withdrawal.args.wad;
+            }
+          }
+          if (amount) {
+            results.push({
+              blockNumber: tx.blockNumber!,
+              txHash: hash,
+              // switch to and from for withdrawals
+              // TODO: not sure how to get where native tokens were transferred to when the tx sender isn't the receiver
+              to: transfer?.args.to || tx.from,
+              from: tx.to || "",
+              token: log.address,
+              amount,
+              isDeposit: false,
+            });
+            return results;
+          }
+        }
+        return results;
+      }, [] as EventData[]);
+      return results;
+    });
+  if (errors.length > 0) {
+    console.error("Errors in Portal's portalNativeAndWrappedTransfersFromHashes", errors);
+  }
+  // aggregate transfers where the token, to, and from values match
+  const aggregated = results.reduce<EventData[]>((aggregated, events) => {
+    if (events) {
+      events.forEach((event) => {
+        const { txHash, token, from, to, amount } = event;
+        const other = aggregated.find(
+          (e) => e.txHash === txHash && e.token === token && e.to === to && e.from === from
+        );
+        if (other) {
+          other.amount.add(amount);
+        } else {
+          aggregated.push(event);
+        }
+      });
+    }
+    return aggregated;
+  }, []);
+  return aggregated;
 };
 
 // checks deposits for Solana as receipient chain, withdrawals for Solana as source chain and returns only those txs
@@ -263,60 +264,43 @@ const processLogsForSolana = async (logs: EventData[], chain: Chain) => {
 };
 
 const constructParams = (chain: string) => {
-  let eventParams = [] as any;
-  const chainAddresses = contractAddresses[chain];
-  const address = chainAddresses.tokenBridge;
-  const nativeToken = chainAddresses.nativeToken;
-  const depositEventParams: PartialContractEventParams = constructTransferParams(address, true);
-  const withdrawalEventParams: PartialContractEventParams = constructTransferParams(address, false, {
-    excludeTo: ["0x0000000000000000000000000000000000000000"],
-  });
-  eventParams.push(depositEventParams, withdrawalEventParams);
+  const { coreBridge, tokenBridge } = contractAddresses[chain];
+  // The token bridge doesn't emit events on deposits/outbound token transfers,
+  // but it calls the core bridge which emits a `LogMessagePublished` event
+  const logMessagePublishedTopic = logMessagePublishedIface.getEventTopic("LogMessagePublished");
+  const logMessagePublishedEventParams: PartialContractEventParams = {
+    target: coreBridge,
+    topic: logMessagePublishedTopic,
+    topics: [logMessagePublishedTopic, ethers.utils.hexZeroPad(tokenBridge, 32)],
+    abi: [logMessagePublishedAbi],
+    isDeposit: true,
+  };
 
   return async (fromBlock: number, toBlock: number) => {
-    const eventLogData = await getTxDataFromEVMEventLogs("portal", chain as Chain, fromBlock, toBlock, eventParams);
-
-    // for native token transfers, only able to get from subgraph, Etherscan API, etc.
+    const events = await getTxDataFromEVMEventLogs("portal", chain as Chain, fromBlock, toBlock, [
+      logMessagePublishedEventParams,
+    ]);
+    let hashes = events.map((e) => e.txHash);
+    // The token bridge doesn't emit events on withdrawals/inbound token transfers,
+    // only able to get from subgraph, Etherscan API, etc.
     // skipped for chains without available API
-    let nativeTokenData = [] as EventData[];
-    if (
-      [
-        "ethereum",
-        "polygon",
-        "fantom",
-        "avalanche",
-        "bsc",
-        "aurora",
-        "celo",
-        "moonbeam",
-        "optimism",
-        "arbitrum",
-        "base",
-      ].includes(chain)
-    ) {
-      if (!nativeToken) {
-        throw new Error(`Chain ${chain} is missing native token address.`);
-      }
+    // TODO: change this when the token bridge emits the `TransferRedeemed` event
+    if (chain !== "klaytn") {
       await getLock();
-      const txs = await getTxsBlockRangeEtherscan(chain, address, fromBlock, toBlock, {
-        includeSignatures: nativeAndWrappedTokenTransferSignatures,
+      const txs = await getTxsBlockRangeEtherscan(chain, tokenBridge, fromBlock, toBlock, {
+        includeSignatures: completeTransferSigs,
       });
       if (txs.length) {
-        const hashes = txs.map((tx: any) => tx.hash);
-        const nativeTokenTransfers = await portalNativeAndWrappedTransfersFromHashes(
-          chain as Chain,
-          hashes,
-          address,
-          nativeToken
-        );
-        nativeTokenData = [...nativeTokenTransfers, ...nativeTokenData];
+        hashes = [...hashes, ...txs.map((tx: any) => tx.hash)];
       }
     }
 
     // every chain also checks for and inserts logs for solana txs
     // const solanaLogs = await processLogsForSolana([...eventLogData, ...nativeTokenData], chain as Chain);
 
-    return [...eventLogData, ...nativeTokenData];
+    const transfers = await portalNativeAndWrappedTransfersFromHashes(chain, hashes, tokenBridge);
+    // console.log(`transfers: ${JSON.stringify(transfers, null, 2)}`);
+    return transfers;
   };
 };
 
@@ -330,7 +314,7 @@ const adapter: BridgeAdapter = {
   celo: constructParams("celo"),
   klaytn: constructParams("klaytn"),
   moonbeam: constructParams("moonbeam"),
-  optimisim: constructParams("optimism"),
+  optimism: constructParams("optimism"),
   arbitrum: constructParams("arbitrum"),
   base: constructParams("base"),
 };

--- a/src/adapters/portal/tests.ts
+++ b/src/adapters/portal/tests.ts
@@ -1,0 +1,461 @@
+import * as ethers from "ethers";
+import adapter from ".";
+import { EventData } from "../../utils/types";
+
+const assertEqual = (expected: EventData, actual: EventData) => {
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    // @ts-ignore
+    const actualValue = actual[key];
+    if (key === "amount" ? !(expectedValue as ethers.BigNumber).eq(actualValue) : expectedValue !== actualValue) {
+      throw new Error(`${key}: expected ${expectedValue}, actual ${actualValue}`);
+    }
+  }
+};
+
+const getEvent = async (blockNumber: number, chain: string = "ethereum") => {
+  const events = await adapter[chain](blockNumber, blockNumber + 1);
+  if (events.length === 0) {
+    throw new Error("no events found");
+  }
+  if (events.length > 1) {
+    throw new Error("found more than one event");
+  }
+  return events[0];
+};
+
+const testNoEventsFound = async () => {
+  const blockNumber = 18114747;
+  const events = await adapter.ethereum(blockNumber, blockNumber + 1);
+  if (events.length !== 0) {
+    throw new Error("events should be empty");
+  }
+};
+
+const testWrapAndTransferEth = async () => {
+  // https://etherscan.io/tx/0x167803810b9274b3c35594a8a50928115141c7cbcc3f973d338ef71e1022729c
+  const blockNumber = 18114746;
+  const event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x167803810b9274b3c35594a8a50928115141c7cbcc3f973d338ef71e1022729c",
+      from: "0x15E9dffFeC3f4E8cFC1b7C5770aa38709a712A3c",
+      to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      amount: ethers.BigNumber.from("1963000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+};
+
+const testWrapAndTransferEthWithPayload = async () => {
+  // https://etherscan.io/tx/0x632164812557f703f93c83bdc6ed4086583a505b8815f7db87b65473f6fccbfe
+  let blockNumber = 18112187;
+  let event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x632164812557f703f93c83bdc6ed4086583a505b8815f7db87b65473f6fccbfe",
+      from: "0xc2A08ff99DF2dD45cA5cF5bc6636954f33294830",
+      to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      amount: ethers.BigNumber.from("30000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://etherscan.io/tx/0xd22e5849c63b4e17ec48aefbdbb4a659a6a516fa73f603c6791ec4780e23782e
+  // relayer contract interaction
+  blockNumber = 18093452;
+  event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0xd22e5849c63b4e17ec48aefbdbb4a659a6a516fa73f603c6791ec4780e23782e",
+      from: "0x072AFd05d41A2a9Ca0fa1755d7B79f861eDb04F3",
+      to: "0xCafd2f0A35A4459fA40C0517e17e6fA2939441CA",
+      token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      amount: ethers.BigNumber.from("3600000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+};
+
+const testTransferTokens = async () => {
+  // https://etherscan.io/tx/0x45fb798f33f3501f43af1d9c312710bc102aa110d732a1ef3491b9f2d1ff8c82
+  // native tokens
+  let blockNumber = 18113848;
+  let event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x45fb798f33f3501f43af1d9c312710bc102aa110d732a1ef3491b9f2d1ff8c82",
+      from: "0xba4eeD5A9E6Acb87e298F6F11e278404f8da28df",
+      to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      amount: ethers.BigNumber.from("5000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+  // https://etherscan.io/tx/0x98ca80f521957c47dc70565c2760e2696edef9fc7e1c78b5a1ed39e4beabece9
+  // wrapped tokens
+  blockNumber = 18128505;
+  event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x98ca80f521957c47dc70565c2760e2696edef9fc7e1c78b5a1ed39e4beabece9",
+      from: "0xC8d5CF84E1aA38fFa9E5E532fc97b2F6e1C4740c",
+      to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      token: "0xE28027c99C7746fFb56B0113e5d9708aC86fAE8f",
+      amount: ethers.BigNumber.from("1428672071062310"),
+      isDeposit: true,
+    },
+    event
+  );
+};
+
+const testTransferTokensWithPayload = async () => {
+  // https://etherscan.io/tx/0xd32b1318b064b4859d2260ebcf116cc1c8687af374e43a83b52d7e059c8a76fb
+  let blockNumber = 18115838;
+  let event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0xd32b1318b064b4859d2260ebcf116cc1c8687af374e43a83b52d7e059c8a76fb",
+      from: "0x6a0Ff6be57DdAbF9F5248a13d3D52e377E310c5d",
+      to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      amount: ethers.BigNumber.from("10000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://etherscan.io/tx/0x14aaac892b3d9cf9d95b1542861ce753213d1b602d4dadfd642687fad6226cdd
+  // relayer contract interaction
+  blockNumber = 18099846;
+  event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x14aaac892b3d9cf9d95b1542861ce753213d1b602d4dadfd642687fad6226cdd",
+      from: "0xdC382CDF2a25790F535a518EC26958c227e9DCF2",
+      to: "0xCafd2f0A35A4459fA40C0517e17e6fA2939441CA",
+      token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      amount: ethers.BigNumber.from("9468893553"),
+      isDeposit: true,
+    },
+    event
+  );
+};
+
+const testCompleteTransferAndUnwrapEth = async () => {
+  // https://etherscan.io/tx/0x6821ce4eca16b4a4ed7ae04bbf30e2e81efae48dc09b362c592e5e3d0fb42580
+  const blockNumber = 18115758;
+  const event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x6821ce4eca16b4a4ed7ae04bbf30e2e81efae48dc09b362c592e5e3d0fb42580",
+      from: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      to: "0x8655F051512899Af8614275e8E31f260eA276267",
+      token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      amount: ethers.BigNumber.from("788573490000000000"),
+      isDeposit: false,
+    },
+    event
+  );
+};
+
+const testCompleteTransferAndUnwrapEthWithPayload = async () => {
+  // https://etherscan.io/tx/0x6821ce4eca16b4a4ed7ae04bbf30e2e81efae48dc09b362c592e5e3d0fb42580
+  const blockNumber = 18115758;
+  const event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x6821ce4eca16b4a4ed7ae04bbf30e2e81efae48dc09b362c592e5e3d0fb42580",
+      from: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      to: "0x8655F051512899Af8614275e8E31f260eA276267",
+      token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      amount: ethers.BigNumber.from("788573490000000000"),
+      isDeposit: false,
+    },
+    event
+  );
+};
+
+const testCompleteTransfer = async () => {
+  // https://etherscan.io/tx/0x75e84975dde7458034da40a3ab56984c85724b5418cc46d98c92f55d124321f5
+  // native tokens
+  let blockNumber = 18115863;
+  let event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x75e84975dde7458034da40a3ab56984c85724b5418cc46d98c92f55d124321f5",
+      from: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      to: "0xe69c250a7D8a2e92b0f1fc3FB29FC64188aA1765",
+      token: "0x41f7B8b9b897276b7AAE926a9016935280b44E97",
+      amount: ethers.BigNumber.from("59522773"),
+      isDeposit: false,
+    },
+    event
+  );
+
+  // https://etherscan.io/tx/0x9fe8bf8ae01790317b92d7bfdb11e735d3db95322129b23f15e1c7f286b8d26a
+  // wrapped tokens
+  blockNumber = 18136907;
+  event = await getEvent(blockNumber);
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x9fe8bf8ae01790317b92d7bfdb11e735d3db95322129b23f15e1c7f286b8d26a",
+      from: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+      to: "0x7B7B957c284C2C227C980d6E2F804311947b84d0",
+      token: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+      amount: ethers.BigNumber.from("1000000000"),
+      isDeposit: false,
+    },
+    event
+  );
+};
+
+// TODO: Add test when token bridge has `TransferRedeemed` event
+// const testCompleteTransferWithPayload = async () => {
+//   // https://etherscan.io/tx/0x0d9693d30aad7ec1e990c7f288869204c28e0ca1e0f202163e5ce6c048e3be2d
+//   // relayer contract interaction
+//   const blockNumber = 18114479;
+//   const event = await getEvent(blockNumber);
+//   assertEqual(
+//     {
+//       blockNumber,
+//       txHash: "0x0d9693d30aad7ec1e990c7f288869204c28e0ca1e0f202163e5ce6c048e3be2d",
+//       from: "0xCafd2f0A35A4459fA40C0517e17e6fA2939441CA",
+//       to: "0xc4834d405fE6c3389c050eA058395F764435e852",
+//       token: "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+//       amount: ethers.BigNumber.from("33000000000"),
+//       isDeposit: false,
+//     },
+//     event
+//   );
+// };
+
+const testAvalanche = async () => {
+  let blockNumber;
+  let event;
+  // https://snowtrace.io/tx/0x71f0028aacdb112eebfed0c45430aeb7ca7229da747c529f5a3cc59feb2e92c7
+  // deposit native tokens
+  blockNumber = 35173920;
+  event = await getEvent(blockNumber, "avalanche");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x71f0028aacdb112eebfed0c45430aeb7ca7229da747c529f5a3cc59feb2e92c7",
+      from: "0xd493066498aCe409059fDA4c1bCD2E73D8cffE01",
+      to: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
+      token: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      amount: ethers.BigNumber.from("10000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://snowtrace.io/tx/0x3841246c0c1f4aa9190cdacddcd3eac6d8bf10562fc2e2b4615484e0694394e6
+  // deposit wrapped tokens
+  blockNumber = 35174152;
+  event = await getEvent(blockNumber, "avalanche");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x3841246c0c1f4aa9190cdacddcd3eac6d8bf10562fc2e2b4615484e0694394e6",
+      from: "0x31eeE3D36b30E26e733B9e11f112c2cb87AbF618",
+      to: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
+      token: "0xDfDA518A1612030536bD77Fd67eAcbe90dDC52Ab",
+      amount: ethers.BigNumber.from("14000000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://snowtrace.io/tx/0xead88482980ba53f92d8cc0d498555e57f540c2324efb17ba12210e2ce9b20b3
+  // withdraw native tokens
+  blockNumber = 35149845;
+  event = await getEvent(blockNumber, "avalanche");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0xead88482980ba53f92d8cc0d498555e57f540c2324efb17ba12210e2ce9b20b3",
+      from: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
+      to: "0xDc8632F46B9b767B2e5ddF8052e2db0cbb66A27f",
+      token: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+      amount: ethers.BigNumber.from("6200806850000000000"),
+      isDeposit: false,
+    },
+    event
+  );
+
+  // https://snowtrace.io/tx/0x6e39e433bc5c52f15eda43d88d31532ce5c26ad78b592b313892898ce8e22427
+  // withdraw wrapped tokens
+  blockNumber = 35214701;
+  event = await getEvent(blockNumber, "avalanche");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x6e39e433bc5c52f15eda43d88d31532ce5c26ad78b592b313892898ce8e22427",
+      from: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
+      to: "0x301371F30d45127E08d0BbE83b870D042089d3e8",
+      token: "0x0950Fc1AD509358dAeaD5eB8020a3c7d8b43b9DA",
+      amount: ethers.BigNumber.from("7000011"),
+      isDeposit: false,
+    },
+    event
+  );
+};
+
+const testOptimism = async () => {
+  // https://optimistic.etherscan.io/tx/0x1254fa3ef00ccb593fa2e2917e13d06c1b0fb40683102cb1a1951c021d2fa64c
+  // deposit native
+  let blockNumber = 109289047;
+  let event = await getEvent(blockNumber, "optimism");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x1254fa3ef00ccb593fa2e2917e13d06c1b0fb40683102cb1a1951c021d2fa64c",
+      from: "0xEC3c8F8582AD5CA88e072F6c8cB2FE1BaAeDA4D0",
+      to: "0x1D68124e65faFC907325e3EDbF8c4d84499DAa8b",
+      token: "0x8B21e9b7dAF2c4325bf3D18c1BeB79A347fE902A",
+      amount: ethers.BigNumber.from("42270000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://optimistic.etherscan.io/tx/0x0aceb4cdce1024236a0cce3ea7632dd26317fec421a3b6ca6baf398c46da79b2
+  // deposit wrapped
+  blockNumber = 109586447;
+  event = await getEvent(blockNumber, "optimism");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x0aceb4cdce1024236a0cce3ea7632dd26317fec421a3b6ca6baf398c46da79b2",
+      from: "0xbC631Fe26bF28fCcb65f72914cEE92fCEbfBdc23",
+      to: "0x1D68124e65faFC907325e3EDbF8c4d84499DAa8b",
+      token: "0xb4B9EEa94D20E8623CC2fb85661E7C94505D3490",
+      amount: ethers.BigNumber.from("225000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://optimistic.etherscan.io/tx/0x63f5e45adc5c8f31b192fe2f4435283f5c0cb9b3e01c89c37739a8ca030b81f6#eventlog
+  // withdraw native
+  blockNumber = 109293169;
+  event = await getEvent(blockNumber, "optimism");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x63f5e45adc5c8f31b192fe2f4435283f5c0cb9b3e01c89c37739a8ca030b81f6",
+      from: "0x1D68124e65faFC907325e3EDbF8c4d84499DAa8b",
+      to: "0x822dB2cE4ACEa6744eCe2F1856d103a244B6Ce07",
+      token: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+      amount: ethers.BigNumber.from("490760019"),
+      isDeposit: false,
+    },
+    event
+  );
+
+  // https://optimistic.etherscan.io/tx/0x1eb1c5d1be5d110fc8a171ddaed8a2daf87a267dda38464555244d871affcf88
+  // withdraw wrapped
+  blockNumber = 109297842;
+  event = await getEvent(blockNumber, "optimism");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x1eb1c5d1be5d110fc8a171ddaed8a2daf87a267dda38464555244d871affcf88",
+      from: "0x1D68124e65faFC907325e3EDbF8c4d84499DAa8b",
+      to: "0x9631288F4050F7CFbf77B77f8540DeCF6cfC7012",
+      token: "0x8418C1d909842f458c9394886b83F19d62bF1A0D",
+      amount: ethers.BigNumber.from("10000000000000000"),
+      isDeposit: false,
+    },
+    event
+  );
+};
+
+const testKlaytn = async () => {
+  // https://scope.klaytn.com/tx/0xc93f8881c85c552043a7ceaccdf628b5375edf6c6d494c1fe004c692546b096f?tabId=eventLog
+  // wrap and transfer
+  let blockNumber = 132658037;
+  let event = await getEvent(blockNumber, "klaytn");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0xc93f8881c85c552043a7ceaccdf628b5375edf6c6d494c1fe004c692546b096f",
+      from: "0xD23b97041B323176C8b595c85b9851b91922e2a9",
+      to: "0x5b08ac39EAED75c0439FC750d9FE7E1F9dD0193F",
+      token: "0xe4f05A66Ec68B54A58B17c22107b02e0232cC817",
+      amount: ethers.BigNumber.from("100000000000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // https://scope.klaytn.com/tx/0x392082d7ba1d55529d572ce6c378f851ae85dac13531153ca919adbc6cde4095?tabId=eventLog
+  // deposit native
+  // approval after transfer event case
+  blockNumber = 132737520;
+  event = await getEvent(blockNumber, "klaytn");
+  assertEqual(
+    {
+      blockNumber,
+      txHash: "0x392082d7ba1d55529d572ce6c378f851ae85dac13531153ca919adbc6cde4095",
+      from: "0x2558963300Eb939F5b0d96eF9a4377d2bEF553a6",
+      to: "0x5b08ac39EAED75c0439FC750d9FE7E1F9dD0193F",
+      token: "0xCd670d77f3dCAB82d43DFf9BD2C4b87339FB3560",
+      amount: ethers.BigNumber.from("20788608176160000000000"),
+      isDeposit: true,
+    },
+    event
+  );
+
+  // Not supported
+  ////https://scope.klaytn.com/tx/0xcd3f53ae2ee584361f5636810af4e1e5984772c867ee6254319038ac2ebf1943?tabId=tokenTransfer
+  //// withdraw wrapped
+  //const blockNumber = 132617076;
+  //const event = await getEvent(blockNumber, "klaytn");
+  //assertEqual(
+  //  {
+  //    blockNumber,
+  //    txHash: "0xcd3f53ae2ee584361f5636810af4e1e5984772c867ee6254319038ac2ebf1943",
+  //    from: "0xb763e8b9208a5a0bef08f200cfc76c0d03e7a5a1",
+  //    to: "0x5b08ac39EAED75c0439FC750d9FE7E1F9dD0193F",
+  //    token: "0x608792deb376cce1c9fa4d0e6b7b44f507cffa6a",
+  //    amount: ethers.BigNumber.from("101706297"),
+  //    isDeposit: false,
+  //  },
+  //  event
+  //);
+};
+
+(async () => {
+  await Promise.all([
+    testNoEventsFound(),
+    testWrapAndTransferEth(),
+    testWrapAndTransferEthWithPayload(),
+    testTransferTokens(),
+    testTransferTokensWithPayload(),
+    testCompleteTransferAndUnwrapEth(),
+    testCompleteTransferAndUnwrapEthWithPayload(),
+    testCompleteTransfer(),
+    // testCompleteTransferWithPayload(),
+    testAvalanche(),
+    testOptimism(),
+    testKlaytn(),
+  ]);
+})();


### PR DESCRIPTION
The Portal token bridge calls into the Wormhole core contract when tokens are deposited or transferred to another chain.  The core contract emits a `LogMessagePublished` event with the Portal token bridge as the sender argument, we can filter on this to get the list of TXs where tokens were deposited. The previous adapter wasn’t including deposits made through internal transactions, this is now fixed. Until the Portal token bridge is upgraded to include the `TransferRedeemed` event, we rely on the Etherscan API to fetch TXs where tokens were withdrawn.