### PR TITLE
Portal - EVM wrapped tokens 'to' address change

### DIFF
--- a/src/adapters/portal/tests.ts
+++ b/src/adapters/portal/tests.ts
@@ -275,10 +275,10 @@ const testAvalanche = async () => {
       blockNumber,
       txHash: "0x3841246c0c1f4aa9190cdacddcd3eac6d8bf10562fc2e2b4615484e0694394e6",
       from: "0x31eeE3D36b30E26e733B9e11f112c2cb87AbF618",
-      to: "0x0000000000000000000000000000000000000000",
+      to: "0x0e082F06FF657D94310cB8cE8B0D9a04541d8052",
       token: "0xDfDA518A1612030536bD77Fd67eAcbe90dDC52Ab",
       amount: ethers.BigNumber.from("14000000000000000000"),
-      isDeposit: true,
+      isDeposit: false,
     },
     event
   );


### PR DESCRIPTION
Wormhole wrapped tokens are burned by the bridge when transferred out from a chain, thus the `to` argument in the wrapped token contract's `Transfer` event is the EVM zero-address. However wormhole wrapped tokens are never double-wrapped, so they should be included in the volume when they're not being sent back to their origination chain where they'd be included in the withdrawal volume when unlocked. This change is consistent with DefiLlama's volume calculation methodology of not double counting token transfers in the volume.