### PR TITLE
[update] remove DLN's withdraw

### DIFF
--- a/src/adapters/debridgedln/index.ts
+++ b/src/adapters/debridgedln/index.ts
@@ -80,12 +80,12 @@ const constructParams = (chain: SupportedChains) => {
     mapTokens: { "0x0000000000000000000000000000000000000000": token },
   };
 
-  const finalWithdrawParams = {
-    ...withdrawParams,
-    mapTokens: { "0x0000000000000000000000000000000000000000": token },
-  };
+  // const finalWithdrawParams = {
+  //   ...withdrawParams,
+  //   mapTokens: { "0x0000000000000000000000000000000000000000": token },
+  // };
 
-  eventParams.push(finalDepositParams, finalWithdrawParams);
+  eventParams.push(finalDepositParams);
 
   return async (fromBlock: number, toBlock: number) =>
     getTxDataFromEVMEventLogs("debridgedln", chain, fromBlock, toBlock, eventParams);


### PR DESCRIPTION
Due to the fact that bridges-server doesn't support Solana, I'll remove 'withdraw' and keep 'deposit.

Please add DLN information:
- Details: DLN is a high-performance cross-chain trading infrastructure built on deBridge with a unique 0-TVL design. Instead of using liquidity pools, DLN pioneered a cross-chain intents model where trades are fulfilled by market makers and MEV searchers instantly and without slippage.
- X/Twitter: https://twitter.com/DLN_Trade
- Website: https://dln.trade/

the debridgedln exports:
```
Getting event logs on chain ethereum from block 18668054 to 18669054.
Getting event logs on chain polygon from block 50484863 to 50485863.
Getting event logs on chain optimism from block 112780395 to 112781395.
Getting event logs on chain avax from block 38343431 to 38344431.
Getting event logs on chain linea from block 999766 to 1000766.
Getting event logs on chain fantom from block 71638815 to 71639815.
Found 10 event logs on chain ethereum.
[ethereum] Deposit 0x2905db4a9af8c8c31d07c3f2a1b723bfccbd9d30148714237ed93b65d29c17c0
[ethereum] Deposit 0x466a3c2d5edb2a26c7ff323806e9f1a9585987ef350528bcef5a81bf002754ed
[ethereum] Deposit 0xce47c73a99a8a3d32f067357360f7e9a3106e5ddf919d932e05aa3a6cfa2a7b4
[ethereum] Deposit 0xac918e052fa34fea29a3d01d83a2bfb97c8821d0b675f73434f1545443e30d51
[ethereum] Deposit 0xa9fb8826ef819384dfdc9effa236b5f0b8e2d2c6e96047ac285070d888620ec0
[ethereum] Deposit 0xea4a842d7233fb3803534e9c41dcbc870eeada98c672810ff940101ec669e566
[ethereum] Deposit 0xa65d6def01b5c8452b9f57858816c2a9c6d6900c49d4934de4706a8a3ffb2e85
[ethereum] Deposit 0xc6469d9fd72a7960b524696e8f8ef9db54cd9d57f28cae06d03bdf56c75ab7f7
[ethereum] Deposit 0x192a3daff80f7f6a7a2b4ade5a265f06724accd03f99a7b5facfba9a1d4ffb95
[ethereum] Deposit 0x0db7eae9e14a0989a5ac4897c6ab2c149dac17359413400b74824a7cd45fcb03
10 transactions found.
Values for event logs have correct types on chain ethereum.
Getting event logs on chain base from block 7184965 to 7185965.
Found 2 event logs on chain linea.
[linea] Deposit 0xa2a9f4b2e091aa926fa1e2f640d1d5b4cd6ebc680f8a456c049b3dc1bfb848ce
[linea] Deposit 0x41482d61fcca511cafa5824195dddb7e566fd6cd82e72e15c36cb23db9e8fee6
2 transactions found.
Values for event logs have correct types on chain linea.
Getting event logs on chain bsc from block 33882073 to 33883073.
No logs received for debridgedln from 38343431 to 38344431 with topic CreatedOrder((uint64,bytes,uint256,bytes,uint256,uint256,bytes,uint256,bytes,bytes,bytes,bytes,bytes,bytes),bytes32,bytes,uint256,uint256,uint32,bytes).
Found 0 event logs on chain avax.
0 transactions found.
Values for event logs have correct types on chain avalanche.
Over the past 1000 blocks, 0 unique tokens were transferred and 0 prices for them were found on avalanche.
Done! avax
Getting event logs on chain arbitrum from block 154857886 to 154858886.
No logs received for debridgedln from 71638815 to 71639815 with topic CreatedOrder((uint64,bytes,uint256,bytes,uint256,uint256,bytes,uint256,bytes,bytes,bytes,bytes,bytes,bytes),bytes32,bytes,uint256,uint256,uint32,bytes).
Found 0 event logs on chain fantom.
0 transactions found.
Values for event logs have correct types on chain fantom.
Over the past 1000 blocks, 0 unique tokens were transferred and 0 prices for them were found on fantom.
Done! fantom
Found 5 event logs on chain polygon.
[polygon] Deposit 0x1b8e930756f153e759b4f6d9ce34dac9748bf628da30c6ee9c32b2aeca90dbeb
[polygon] Deposit 0x3dcdd5e27c5d66efbb269827b8924ee02628111c86b868436916b4329cfa1f28
[polygon] Deposit 0xd17717034b62ce33674706cf21f3bb0afd22dee9410887a3a56294f74cc016dc
[polygon] Deposit 0xfaca0a9a24002b61feeea77c5b385451d6b5112afd1c91d435433914de91b88c
[polygon] Deposit 0x67c0e672ae6b2d16dd6c0e528b1a6de96df97571374bc01a29cc84dcc79ac85e
5 transactions found.
Values for event logs have correct types on chain polygon.
Found 2 event logs on chain optimism.
[optimism] Deposit 0x5c947de38ee1e088a94eec8fe02a042a3165fa4bb3d1656e694e94a8d204f856
[optimism] Deposit 0x21c57409b7a7ed053efb0dc3d5cd955fa201e542edbe78e081864a27881a0c86
2 transactions found.
Values for event logs have correct types on chain optimism.
Found 1 event logs on chain base.
[base] Deposit 0x589a4e0f3412e761527e691dda04a567a62f03205153da7f65c2dc831aaf46a5
1 transactions found.
Values for event logs have correct types on chain base.
Over the past 1000 blocks, 3 unique tokens were transferred and 2 prices for them were found on ethereum.
token ethereum:0x9d3d07439069c9bbc8d626397cf98cb343ac0a72 is missing price.
Done! ethereum
Found 1 event logs on chain arbitrum.
[arbitrum] Deposit 0x6b221c3c2846fb9a92481507afc8ac6d3ad28572a9b967686549907aa095f4c5
1 transactions found.
Values for event logs have correct types on chain arbitrum.
Over the past 1000 blocks, 2 unique tokens were transferred and 2 prices for them were found on polygon.
Done! polygon
Over the past 1000 blocks, 2 unique tokens were transferred and 2 prices for them were found on optimism.
Done! optimism
Over the past 1000 blocks, 1 unique tokens were transferred and 1 prices for them were found on linea.
Done! linea
Over the past 1000 blocks, 1 unique tokens were transferred and 1 prices for them were found on base.
Done! base
Over the past 1000 blocks, 1 unique tokens were transferred and 1 prices for them were found on arbitrum.
Done! arbitrum
```