### PR TITLE
Solana - getBlockByTimestamp support

### DIFF
--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -1,7 +1,8 @@
-import { getLatestBlock as getLatestBlockSdk } from "@defillama/sdk/build/util";
+import { getLatestBlock as getLatestBlockSdk, lookupBlock } from "@defillama/sdk/build/util";
 // import { getClient } from "../helpers/sui";
 import { tronGetLatestBlock } from "../helpers/tron";
 import { getConnection } from "../helpers/solana";
+import { Chain } from "@defillama/sdk/build/general";
 
 export async function getLatestBlockNumber(chain: string): Promise<number> {
   if (chain === "sui") {
@@ -34,4 +35,20 @@ export async function getLatestBlock(chain: string): Promise<{ number: number; t
     return { number, timestamp };
   }
   return await getLatestBlockSdk(chain);
+}
+
+export async function getBlockByTimestamp(timestamp: number, chain: Chain) {
+  if (chain === "solana") {
+    const { timestamp: latestTimestamp, number } = await getLatestBlock(chain);
+    // There is not an easy way to get the slot number from a timestamp on Solana
+    // without hammering the RPC node with requests.
+    // So we estimate it by assuming that a slot is produced every 400ms.
+    if (timestamp <= latestTimestamp) {
+      const slot = number - Math.floor(((latestTimestamp - timestamp) * 1000) / 400);
+      return { block: slot, timestamp };
+    }
+  } else {
+    return await lookupBlock(timestamp, { chain });
+  }
+  throw new Error(`Could not find block for timestamp ${timestamp} on chain ${chain}`);
 }

--- a/src/utils/runAdapterHistorical.ts
+++ b/src/utils/runAdapterHistorical.ts
@@ -1,8 +1,8 @@
 import { Chain } from "@defillama/sdk/build/general";
-import { lookupBlock } from "@defillama/sdk/build/util";
 import bridgeNetworkData from "../data/bridgeNetworkData";
 import { wait } from "../helpers/etherscan";
 import { runAdapterHistorical } from "./adapter";
+import { getBlockByTimestamp } from "./blocks";
 
 const startTs = Number(process.argv[2]);
 const endTs = Number(process.argv[3]);
@@ -35,8 +35,8 @@ async function fillAdapterHistorical(
       if (restrictChainTo && nChain !== restrictChainTo) return;
       console.log(`Running adapter for ${chain} for ${bridgeDbName}`);
       await wait(500 * i);
-      const startBlock = await lookupBlock(startTimestamp, { chain: nChain as Chain });
-      const endBlock = await lookupBlock(endTimestamp, { chain: nChain as Chain });
+      const startBlock = await getBlockByTimestamp(startTimestamp, nChain as Chain);
+      const endBlock = await getBlockByTimestamp(endTimestamp, nChain as Chain);
       await runAdapterHistorical(
         startBlock.block,
         endBlock.block,


### PR DESCRIPTION
We estimate the block for a timestamp for Solana.
Prevents us from getting throttled by the RPC node.