### PR TITLE
Rootstock Bridge Change Name - Powpeg

### DIFF
--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -759,7 +759,7 @@ export default [
 
   {
     id: 48,
-    displayName: "Rootstock Bridge",
+    displayName: "Rootstock Powpeg Bridge",
     bridgeDbName: "rootstock",
     iconLink: "chain:rootstock",
     largeTxThreshold: 10000,


### PR DESCRIPTION
Change the display name of Rootstock Bridge to Rootstock Powpeg Bridge