### PR TITLE
[update] deBridge product name

### DIFF
--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -314,9 +314,9 @@ export default [
 
   {
     id: 20,
-    displayName: "DLN (Powered by deBridge)",
+    displayName: "deBridge",
     bridgeDbName: "debridgedln",
-    iconLink: "icons:debridgedln",
+    iconLink: "icons:debridge",
     largeTxThreshold: 10000,
     url: "https://debridge.finance/",
     chains: ["Ethereum", "Polygon", "Arbitrum", "Avalanche", "BSC", "Fantom", "Optimism", "Linea", "Base"],


### PR DESCRIPTION
This PR renames deBridge's product name and logo to better reflect branding