### PR TITLE
XY Finance: add x layer config

### DIFF
--- a/src/adapters/xy-finance/constants.ts
+++ b/src/adapters/xy-finance/constants.ts
@@ -21,6 +21,7 @@ export enum Chain {
   Numbers = 'numbers',
   Wemix = 'wemix',
   Blast = 'blast',
+  XLayer = 'xLayer'
 }
 
 export enum VAULTS_TOKEN {
@@ -328,6 +329,20 @@ export const YBridgeVaultsTokenContractAddress: Record<Exclude<Chain, Chain.Numb
       contractAddress: '0xFa77c2DecCB21ACb9Bf196408Bf6aD5973D07762',
       tokenAddress: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
     },
+  },
+  [Chain.XLayer]: {
+    [VAULTS_TOKEN.USDT]: {
+      contractAddress: '0x1e4992E1Be86c9d8ed7dcBFcF3665FE568dE98Ab',
+      tokenAddress: '0x1E4a5963aBFD975d8c9021ce480b42188849D41d'
+    },
+    [VAULTS_TOKEN.USDC]: {
+      contractAddress: '',
+      tokenAddress: ''
+    },
+    [VAULTS_TOKEN.ETH]: {
+      contractAddress: '0xFa77c2DecCB21ACb9Bf196408Bf6aD5973D07762',
+      tokenAddress: '0x5A77f1443D16ee5761d310e38b62f77f726bC71c'
+    },
   }
 }
 
@@ -353,6 +368,7 @@ export const YBridgeContractAddress: Record<Exclude<Chain, Chain.Numbers>, Contr
   [Chain.ThunderCore]: "0xF103b5B479d2A629F422C42bb35E7eEceE1ad55E",
   [Chain.Wemix]: "0x73Ce60416035B8D7019f6399778c14ccf5C9c7A1",
   [Chain.Blast]: "0x73Ce60416035B8D7019f6399778c14ccf5C9c7A1",
+  [Chain.XLayer]: "0x73Ce60416035B8D7019f6399778c14ccf5C9c7A1"
 }
 
 export const XYRouterContractAddress: Record<Chain, ContractAddress> = {
@@ -378,4 +394,5 @@ export const XYRouterContractAddress: Record<Chain, ContractAddress> = {
   [Chain.Numbers]: "0x1acCfC3a45313f8F862BE7fbe9aB25f20A93d598",
   [Chain.Wemix]: "0x6471fAd467ac2854b403e7FE3e95FBbB3287a7ee",
   [Chain.Blast]: "0x43A86823EBBe2ECF9A384aDfD989E26A30626458",
+  [Chain.XLayer]: "0x6A816cEE105a9409D8df0A83d8eeaeD9EB4309fE"
 }

--- a/src/adapters/xy-finance/index.ts
+++ b/src/adapters/xy-finance/index.ts
@@ -155,6 +155,7 @@ const adapter: BridgeAdapter = {
   thundercore: constructParams(Chain.ThunderCore),
   wemix: constructParams(Chain.Wemix),
   blast: constructParams(Chain.Blast),
+  'x layer': constructParams(Chain.XLayer),
 };
 
 export default adapter;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -746,12 +746,14 @@ export default [
       "Moonriver",
       "ThunderCore",
       "Blast",
+      "X Layer"
       // "Numbers",
     ],
     chainMapping: {
       "zksync era": "era",
       "polygon zkevm": "polygon_zkevm",
       avalanche: "avax",
+      "x layer": "xlayer"
     },
   },
   // {


### PR DESCRIPTION
Hi @vrtnd Please help review the PR 🙏 

This is XY Finance, we have recently started supporting X layer chain and would like to add new config, but we got errors when running the test, it seems other libraries (sdk) need to be updated as well, please let us know where we should help to update.

```
TypeError: Cannot read properties of null (reading 'getBlock')
    at _getCurrentChainBlock (/Users/ryanc/Desktop/XY/bridges-server/node_modules/@defillama/sdk/build/util/blocks.js:84:59)
    at getCurrentChainBlock (/Users/ryanc/Desktop/XY/bridges-server/node_modules/@defillama/sdk/build/util/blocks.js:76:22)
```
