### PR TITLE
Get the starting block from defillama

### DIFF
--- a/src/adapters/ibc/index.ts
+++ b/src/adapters/ibc/index.ts
@@ -1,13 +1,54 @@
+import retry from "async-retry"
+import axios from "axios";
+
 import { BridgeNetwork } from "../../data/types";
 import { BridgeAdapter } from "../../helpers/bridgeAdapter.type";
 import { 
   getBlockFromTimestamp, 
   getIbcVolumeByZoneId, 
-  getLatestBlockForZone
+  getLatestBlockForZone,
 } from "../../helpers/mapofzones";
 import bridges from "../../data/bridgeNetworkData";
 
 const ibcBridgeNetwork = bridges.find((bridge) => bridge.bridgeDbName === "ibc");
+const DEFILLAMA_LATEST_BLOCK_URL = "https://llama-bridges-data.s3.eu-central-1.amazonaws.com/lastRecordedBlocks.json";
+
+export const getBlockToStartFromDefillama = async (bridge: BridgeNetwork, chain: string, timestamp: number): Promise<{
+  block: number;
+} | undefined> => {
+  const response = await retry(async (_bail) => await axios.get(
+    DEFILLAMA_LATEST_BLOCK_URL
+  ))
+
+  const data = await response.data;
+
+  if (!data) {
+    console.log(`Failed to fetch latest block for ${chain}`);
+    return undefined;
+  }
+
+  const chainName = findChainName(bridge, chain);
+
+  const block = data[`ibc-${chainName}`];
+
+  if (block) {
+    return {
+      block: block.endBlock + 1,
+    };
+  }
+  // for new chains may be they have not been added to defillama yet
+  // fallback to the timestamp
+  const blockFromTimestamp = await ibcGetBlockFromTimestamp(bridge, timestamp, chain, 'First');
+  if (!blockFromTimestamp) {
+    console.log(`Could not find block for ${chain} from timestamp ${timestamp}`);
+    return undefined;
+  }
+
+  return {
+    block: blockFromTimestamp.block,
+  };
+
+}
 
 export const getLatestBlockForZoneFromMoz = async (zoneId: string): Promise<{
   number: number;
@@ -41,6 +82,18 @@ export const findChainId = (bridgeNetwork: BridgeNetwork, chain: string) => {
     return bridgeNetwork.chainMapping[chain];
   } else if (Object.values(bridgeNetwork.chainMapping).includes(chain)) {
     return chain;
+  }
+}
+
+export const findChainName = (bridgeNetwork: BridgeNetwork, chainId: string) => {
+  if (bridgeNetwork.chainMapping === undefined) {
+    throw new Error("Chain mapping is undefined for ibc bridge network.");
+  }
+
+  for (const [key, value] of Object.entries(bridgeNetwork.chainMapping)) {
+    if (value === chainId) {
+      return key;
+    }
   }
 }
 

--- a/src/utils/runAdapterHistorical.ts
+++ b/src/utils/runAdapterHistorical.ts
@@ -3,6 +3,7 @@ import bridgeNetworkData from "../data/bridgeNetworkData";
 import { wait } from "../helpers/etherscan";
 import { runAdapterHistorical } from "./adapter";
 import { getBlockByTimestamp } from "./blocks";
+import { getBlockToStartFromDefillama } from "../adapters/ibc";
 
 const startTs = Number(process.argv[2]);
 const endTs = Number(process.argv[3]);
@@ -42,7 +43,7 @@ async function fillAdapterHistorical(
       let startBlock;
       let endBlock;
       if(bridgeDbName === "ibc") {
-        startBlock = await getBlockByTimestamp(startTimestamp, nChain as Chain, adapter, "First");
+        startBlock = await getBlockToStartFromDefillama(adapter, nChain as Chain, startTimestamp);
         if (!startBlock) {
           console.error(`Could not find start block for ${chain} on ${bridgeDbName}`);
           return;
@@ -52,6 +53,11 @@ async function fillAdapterHistorical(
           console.error(`Could not find end block for ${chain} on ${bridgeDbName}`);
           return;
         }
+
+        if (startBlock.block > endBlock.block) {
+          return;
+        }        
+  
       } else {
         startBlock = await getBlockByTimestamp(startTimestamp, nChain as Chain);
         endBlock = await getBlockByTimestamp(endTimestamp, nChain as Chain);


### PR DESCRIPTION
When two timestamps will be passed to the collector, this PR will replace getting the starting block directly from the timestamp, but instead uses the latest recorded block from Defillama. It will use the passed timestamp as a fallback in case it was not able to get the latest recorded block.