### PR TITLE
deBridge: track turnover from/to Solana via the api

### DIFF
--- a/src/adapters/debridgedln/index.ts
+++ b/src/adapters/debridgedln/index.ts
@@ -1,5 +1,9 @@
 import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
+import { ethers } from "ethers";
+import fetch from "node-fetch";
+import { EventData } from "../../utils/types";
+const retry = require("async-retry");
 
 /**
  * deBridge is a messaging infrastructure. DLN is a cross-chain trading infrastructure
@@ -49,28 +53,6 @@ const depositPrarms: PartialContractEventParams = {
   isDeposit: true,
 };
 
-// since doesn't support solana, need set withdraw = deposit
-// after support solana, change to original withdraw
-// const withdrawParams: PartialContractEventParams = {
-//   target: evmContracts.dlnSource,
-//   topic:
-//     "CreatedOrder((uint64,bytes,uint256,bytes,uint256,uint256,bytes,uint256,bytes,bytes,bytes,bytes,bytes,bytes),bytes32,bytes,uint256,uint256,uint32,bytes)",
-//   abi: [
-//     "event CreatedOrder((uint64 makerOrderNonce, bytes makerSrc, uint256 giveChainId, bytes giveTokenAddress, uint256 giveAmount, uint256 takeChainId, bytes takeTokenAddress, uint256 takeAmount, bytes receiverDst, bytes givePatchAuthoritySrc, bytes orderAuthorityAddressDst, bytes allowedTakerDst, bytes allowedCancelBeneficiarySrc, bytes externalCall) order, bytes32 orderId, bytes affiliateFee, uint256 nativeFixFee, uint256 percentFee, uint32 referralCode, bytes metadata)",
-//   ],
-//   logKeys: {
-//     blockNumber: "blockNumber",
-//     txHash: "transactionHash",
-//   },
-//   argKeys: {
-//     amount: "order.giveAmount",
-//     to: "order.receiverDst",
-//     from: "order.makerSrc",
-//     token: "order.giveTokenAddress",
-//   },
-//   isDeposit: false,
-// };
-
 const withdrawParams: PartialContractEventParams = {
   target: evmContracts.dlnDestination,
   topic:
@@ -113,7 +95,44 @@ const constructParams = (chain: SupportedChains) => {
     getTxDataFromEVMEventLogs("debridgedln", chain, fromBlock, toBlock, eventParams);
 };
 
-// need add solana and heco
+type ApiSolanaEvent = {
+  blockNumber: number,
+  txHash: string,
+  from: string,
+  to: string,
+  token: string,
+  amount: string,
+  isDeposit: boolean;
+  giveAmountUSD: number;
+}
+
+const solanaBlockNumberFirstUsedByDebridge = 166833820;
+
+const fetchSolanaEvents = async (fromBlock: number, toBlock: number): Promise<ApiSolanaEvent[]> => {
+  return retry(() => fetch(
+    `https://stats-api.dln.trade/api/OrderEvents/solanaDepositsAndWithdrawals?fromBlock=${fromBlock}&toBlock=${toBlock}`
+    )
+    .then(res => res.json())
+  )
+}
+
+const getSolanaEvents = async (fromBlock: number, toBlock: number): Promise<EventData[]> => {
+  // Performance optimization: deBridge does not have any orders from Solana prior this block
+  if (toBlock < solanaBlockNumberFirstUsedByDebridge) {
+    return [];
+  }
+
+  const events = await fetchSolanaEvents(fromBlock, toBlock)
+
+  return events.map((event) => (<EventData>{
+    ...event,
+    token: event.token === '11111111111111111111111111111111'
+      ? 'So11111111111111111111111111111111111111112'
+      : event.token,
+    amount: ethers.BigNumber.from(Math.round(event.giveAmountUSD)),
+    isUSDVolume: true,
+  }));
+};
 
 const adapter: BridgeAdapter = {
   ethereum: constructParams("ethereum"),
@@ -125,6 +144,7 @@ const adapter: BridgeAdapter = {
   linea: constructParams("linea"),
   optimism: constructParams("optimism"),
   base: constructParams("base"),
+  solana: getSolanaEvents,
 };
 
 export default adapter;


### PR DESCRIPTION
This PR introduces the retrieval of deposits to Solana and withdrawals from Solana to reflect actual deBridge turnover.