### PR TITLE
XY Finance: add NativeTokens maps

### DIFF
--- a/src/adapters/xy-finance/constants.ts
+++ b/src/adapters/xy-finance/constants.ts
@@ -31,11 +31,32 @@ export enum VAULTS_TOKEN {
   ETH
 }
 
-type ContractAddress = string
+type Address = string
 type YBridgeVaultsTokenAddress = Record<VAULTS_TOKEN, {
-  contractAddress: ContractAddress
-  tokenAddress: ContractAddress
+  contractAddress: Address
+  tokenAddress: Address
 }>
+
+export const ETH_ADDRESS: Address = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+
+export const NativeTokens: Partial<Record<Chain, string>> = {
+  [Chain.Ethereum]: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+  [Chain.Arbitrum]: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+  [Chain.Optimism]: "0x4200000000000000000000000000000000000006",
+  [Chain.Base]: "0x4200000000000000000000000000000000000006",
+  [Chain.Linea]: "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
+  [Chain.Blast]: "0x4300000000000000000000000000000000000004",
+  [Chain.Polygon]: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+  [Chain.Scroll]: "0x5300000000000000000000000000000000000004",
+  [Chain.PolygonZkevm]: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+  [Chain.ZkSync]: "0x5AEa5775959fBC2557Cc8789bC1bf90A239D9a91",
+  [Chain.XLayer]: "0x5a77f1443d16ee5761d310e38b62f77f726bc71c",
+  [Chain.Bsc]: "0x2170Ed0880ac9A755fd29B2688956BD959F933F8",
+  [Chain.Mantle]: "0xdeaddeaddeaddeaddeaddeaddeaddeaddead1111",
+  [Chain.Taiko]: "0xA51894664A773981C6C112C43ce576f315d5b1B6",
+  [Chain.Avalanche]: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
+};
+
 export const YBridgeVaultsTokenContractAddress: Record<Exclude<Chain, Chain.Numbers>, YBridgeVaultsTokenAddress> = {
   [Chain.Ethereum]: {
     [VAULTS_TOKEN.USDT]: {
@@ -361,7 +382,7 @@ export const YBridgeVaultsTokenContractAddress: Record<Exclude<Chain, Chain.Numb
   }
 }
 
-export const YBridgeContractAddress: Record<Exclude<Chain, Chain.Numbers>, ContractAddress> = {
+export const YBridgeContractAddress: Record<Exclude<Chain, Chain.Numbers>, Address> = {
   [Chain.Ethereum]: '0x4315f344a905dC21a08189A117eFd6E1fcA37D57',
   [Chain.Scroll]: "0x778C974568e376146dbC64fF12aD55B2d1c4133f",
   [Chain.Mantle]: "0x73Ce60416035B8D7019f6399778c14ccf5C9c7A1",
@@ -387,7 +408,7 @@ export const YBridgeContractAddress: Record<Exclude<Chain, Chain.Numbers>, Contr
   [Chain.Taiko]: "0x73Ce60416035B8D7019f6399778c14ccf5C9c7A1"
 }
 
-export const XYRouterContractAddress: Record<Chain, ContractAddress> = {
+export const XYRouterContractAddress: Record<Chain, Address> = {
   [Chain.Ethereum]: "0xFfB9faf89165585Ad4b25F81332Ead96986a2681",
   [Chain.Scroll]: "0x22bf2A9fcAab9dc96526097318f459eF74277042",
   [Chain.Mantle]: "0x52075Fd1fF67f03beABCb5AcdA9679b02d98cA37",

--- a/src/adapters/xy-finance/index.ts
+++ b/src/adapters/xy-finance/index.ts
@@ -4,6 +4,8 @@ import { BridgeAdapter, ContractEventParams, PartialContractEventParams } from "
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 import {
   Chain,
+  ETH_ADDRESS,
+  NativeTokens,
   XYRouterContractAddress,
   YBridgeContractAddress,
   YBridgeVaultsTokenContractAddress
@@ -28,6 +30,13 @@ const getYBridgeSwapRequestedEventParams = (chain: Exclude<Chain, Chain.Numbers>
       to: "_referrer",
     },
     argGetters: {
+      token: (log: any) => {
+        const token = log?._vaultToken
+        if (token?.toLowerCase() === ETH_ADDRESS.toLowerCase()) {
+          return NativeTokens[chain] || token
+        }
+        return token
+      },
       to: (log: any) => {
         const vaultToken = log?._vaultToken
         const toVaultContract = find(YBridgeVaultsTokenContractAddress[chain], { tokenAddress: vaultToken })?.contractAddress
@@ -55,6 +64,15 @@ const getYBridgeSwappedForUserEventParams = (chain: Exclude<Chain, Chain.Numbers
       amount: "_dstTokenAmountOut",
       from: "_srcToken",
       to: "_receiver",
+    },
+    argGetters: {
+      token: (log: any) => {
+        const token = log?._dstToken
+        if (token?.toLowerCase() === ETH_ADDRESS.toLowerCase()) {
+          return NativeTokens[chain] || token
+        }
+        return token
+      },
     },
     isDeposit: false,
   }


### PR DESCRIPTION
Hi @vrtnd 
This is Ryan from XY Finance, we recently found there is only USDC symbol on taiko table, but there should be several ETH related transactions through our bridge, it seems we need to have native token map like other bridges do, please help review the PR and merge, many thanks 🙏 

<img width="1259" alt="image" src="https://github.com/user-attachments/assets/1ad349a8-f210-44a8-9551-b6e28dff88cc">

### Evidence
- Before
<img width="1040" alt="截圖 2024-08-07 下午4 49 31" src="https://github.com/user-attachments/assets/87b23278-5448-4bdf-894a-3c70a999da84">

- After
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/f99dddd5-86af-4098-85b0-74ef8c4ae894">
