### PR TITLE
ENH: Add Blast/Scroll to Across adapter

### DIFF
--- a/src/adapters/across/index.ts
+++ b/src/adapters/across/index.ts
@@ -31,9 +31,9 @@ const contracts = {
   era: {
     spokePoolv2p5: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
   },
-  // Chain id: 1135
+  // Chain id: 1135 (TODO: Add Lisk to llama-sdk first)
   // lisk: {
-    // spokePoolv2p5: "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+  //  spokePoolv2p5: "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
   // },
   // Chain id: 8453
   base: {
@@ -241,7 +241,7 @@ const adapter: BridgeAdapter = {
   optimism: constructParams("optimism"),
   polygon: constructParams("polygon"),
   "zksync era": constructParams("era"),
-  lisk: constructParams("lisk"),
+  // lisk: constructParams("lisk"),
   base: constructParams("base"),
   mode: constructParams("mode"),
   arbitrum: constructParams("arbitrum"),

--- a/src/adapters/across/index.ts
+++ b/src/adapters/across/index.ts
@@ -238,13 +238,16 @@ const constructParams = (chain: SupportedChains) => {
 
 const adapter: BridgeAdapter = {
   ethereum: constructParams("ethereum"),
-  polygon: constructParams("polygon"),
-  arbitrum: constructParams("arbitrum"),
   optimism: constructParams("optimism"),
+  polygon: constructParams("polygon"),
   "zksync era": constructParams("era"),
+  lisk: constructParams("lisk"),
   base: constructParams("base"),
-  linea: constructParams("linea"),
   mode: constructParams("mode"),
+  arbitrum: constructParams("arbitrum"),
+  linea: constructParams("linea"),
+  blast: constructParams("blast"),
+  scroll: constructParams("scroll"),
 };
 
 export default adapter;

--- a/src/adapters/across/index.ts
+++ b/src/adapters/across/index.ts
@@ -12,34 +12,54 @@ For all tokens using 'spokepool' contracts:
 */
 
 const contracts = {
+  // Chain id: 1
   ethereum: {
     spokePoolv2: "0x4D9079Bb4165aeb4084c526a32695dCfd2F77381",
     spokePoolv2p5: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5",
   },
-  polygon: {
-    spokePoolv2: "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
-    spokePoolv2p5: "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
-  },
-  arbitrum: {
-    spokePoolv2: "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
-    spokePoolv2p5: "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
-  },
+  // Chain id: 10
   optimism: {
     spokePoolv2: "0xa420b2d1c0841415A695b81E5B867BCD07Dff8C9",
     spokePoolv2p5: "0x6f26Bf09B1C792e3228e5467807a900A503c0281",
   },
+  // Chain id: 137
+  polygon: {
+    spokePoolv2: "0x69B5c72837769eF1e7C164Abc6515DcFf217F920",
+    spokePoolv2p5: "0x9295ee1d8C5b022Be115A2AD3c30C72E34e7F096",
+  },
+  // Chain id: 324
   era: {
     spokePoolv2p5: "0xE0B015E54d54fc84a6cB9B666099c46adE9335FF",
   },
+  // Chain id: 1135
+  // lisk: {
+    // spokePoolv2p5: "0x9552a0a6624A23B848060AE5901659CDDa1f83f8",
+  // },
+  // Chain id: 8453
   base: {
     spokePoolv2p5: "0x09aea4b2242abC8bb4BB78D537A67a245A7bEC64",
   },
-  linea: {
-    spokePoolv2p5: "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75",
-  },
+  // Chain id: 34443
   mode: {
     spokePoolv2p5: "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
   },
+  // Chain id: 42161
+  arbitrum: {
+    spokePoolv2: "0xB88690461dDbaB6f04Dfad7df66B7725942FEb9C",
+    spokePoolv2p5: "0xe35e9842fceaCA96570B734083f4a58e8F7C5f2A",
+  },
+  // Chain id: 59144
+  linea: {
+    spokePoolv2p5: "0x7E63A5f1a8F0B4d0934B2f2327DAED3F6bb2ee75",
+  },
+  // Chain id: 81457
+  blast: {
+    spokePoolv2p5: "0x2D509190Ed0172ba588407D4c2df918F955Cc6E1",
+  },
+  // Chain id: 534352
+  scroll: {
+    spokePoolv2p5: "0x3baD7AD0728f9917d1Bf08af5782dCbD516cDd96",
+  }
 } as const;
 
 type SupportedChains = keyof typeof contracts;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -324,7 +324,18 @@ export default [
     iconLink: "icons:across",
     largeTxThreshold: 10000,
     url: "https://across.to/",
-    chains: ["Ethereum", "Polygon", "Arbitrum", "Optimism", "zkSync Era", "Base", "Linea", "Mode"],
+    chains: [
+      "Ethereum",
+      "Polygon",
+      "Optimism",
+      "zkSync Era",
+      "Base",
+      "Arbitrum",
+      "Linea",
+      "Mode",
+      "Blast",
+      "Scroll"
+    ],
     chainMapping: {
       "zksync era": "era",
     },


### PR DESCRIPTION
This PR adds Blast and Scroll as supported chains to the Across adapter.