### PR TITLE
new Bitlayer USDC address

### DIFF
--- a/src/adapters/zkbridge/contants.ts
+++ b/src/adapters/zkbridge/contants.ts
@@ -333,7 +333,7 @@ const zkbridgeContractes = {
                 shareDecimal: 6
             },
             2: {
-                tokenAddress: "0x9827431e8b77e87c9894bd50b055d6be56be0030",
+                tokenAddress: "0xf8c374ce88a3be3d374e8888349c7768b607c755",
                 tokenDecimal: 6,
                 shareDecimal: 6
             },


### PR DESCRIPTION
This PR was created to update the USDC Token contract address on the Bitlayer chain.

To comply with Circle's protocol requirements and ensure the stability and compliance of the Bitlayer ecosystem, Bitlayer has renamed the USDC Token. For details, please refer to: https://blog.bitlayer.org/USDC_._e_to_USDC_Conversion_Guide

As a result, we have updated the code to modify the contract address of the USDC Token. Please review and merge the changes. Thank you!