### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ abi: ["event ETHWithdrawalFinalized(address indexed _from, address indexed _to, 
 isDeposit: false, // event type 
 logKeys: {
   blockNumber:  "blockNumber", 
-  txHash:  "transactionHash",// if event log data key != adapter ouptup key
+  txHash:  "transactionHash",// if event log data key != adapter output key
 },
 argKeys: {
   to: "_to", 


### PR DESCRIPTION
<img width="606" alt="Снимок экрана 2024-11-12 в 15 25 11" src="https://github.com/user-attachments/assets/c556a2bc-2a48-4890-8c5b-e0c480af7323">

Corrected "**output**" instead of "ouptup".