### PR TITLE
fix: month display issue in `getUTCMonth()`

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -85,7 +85,7 @@ export function getDay(timestamp: number | undefined): string {
     return "none";
   }
   var dt = new Date(timestamp * 1000);
-  return `${dt.getUTCDate()}-${dt.getUTCMonth()}-${dt.getUTCFullYear()}`;
+  return `${dt.getUTCDate()}-${dt.getUTCMonth() + 1}-${dt.getUTCFullYear()}`;
 }
 
 export function getClosestDayStartTimestamp(timestamp: number) {


### PR DESCRIPTION
 updated the code to adjust the result of `getUTCMonth()` so that it returns the correct month in the familiar format (1 for January, 2 for February, etc.).

the method originally returns a month in the 0–11 range, and I’ve added `+1` to ensure the output matches user expectations.