### PR TITLE
refactor: replace old getLogs with sdk.getLogs v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ syntax: `npm run {script-name} {startTimestamp} {endTimestamp} {bridgeName}`
 
 Example: 
 ```
-npm run adapter arbitrum 1704690402 1704949602
-npm run aggregate arbitrum 1704690402 1704949602
-npm run daily-volume arbitrum 1704690402 1704949602 
+npm run adapter 1704690402 1704949602 arbitrum
+npm run aggregate 1704690402 1704949602 arbitrum
+npm run daily-volume 1704690402 1704949602 arbitrum
 ```
 Returns: 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@aws-sdk/client-s3": "^3.749.0",
         "@aws-sdk/client-sts": "^3.749.0",
         "@aws-sdk/credential-providers": "^3.749.0",
-        "@defillama/sdk": "^5.0.137",
+        "@defillama/sdk": "^5.0.154",
         "@fastify/cors": "^9.0.1",
         "@graphql-typed-document-node/core": "^3.2.0",
         "@solana/web3.js": "^1.87.3",
@@ -6588,9 +6588,9 @@
       }
     },
     "node_modules/@defillama/sdk": {
-      "version": "5.0.137",
-      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.137.tgz",
-      "integrity": "sha512-qeLgEy8fuQsE2HOojyQSHCQ3fgIJmNZwX7Nqc5Vs9QEKrq3LBGPxM/MZPoBuIm7GiPM57rJGRf6tE0u/oR2KQQ==",
+      "version": "5.0.160",
+      "resolved": "https://registry.npmjs.org/@defillama/sdk/-/sdk-5.0.160.tgz",
+      "integrity": "sha512-J76fh+jm9f5NeJPXpQHHPuEguxcwBZ1iKVhUOu7Eg5aWKRJoUlSDhs55T25VtndtdsIiLVPM8yJ1Vqs+IyHVFQ==",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.400.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@aws-sdk/client-s3": "^3.749.0",
     "@aws-sdk/client-sts": "^3.749.0",
     "@aws-sdk/credential-providers": "^3.749.0",
-    "@defillama/sdk": "^5.0.137",
+    "@defillama/sdk": "^5.0.154",
     "@fastify/cors": "^9.0.1",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@solana/web3.js": "^1.87.3",

--- a/src/helpers/processTransactions.ts
+++ b/src/helpers/processTransactions.ts
@@ -1,4 +1,3 @@
-import { getLogs } from "@defillama/sdk/build/util";
 import { ethers } from "ethers";
 import { Chain } from "@defillama/sdk/build/general";
 import { get } from "lodash";
@@ -6,6 +5,7 @@ import { ContractEventParams, PartialContractEventParams } from "../helpers/brid
 import { EventData } from "../utils/types";
 import { PromisePool } from "@supercharge/promise-pool";
 import { getProvider } from "../utils/provider";
+import { getEventLogs } from "@defillama/sdk";
 
 const EventKeyTypes = {
   blockNumber: "number",
@@ -125,18 +125,17 @@ export const getTxDataFromEVMEventLogs = async (
       let logs = [] as any[];
       for (let i = 0; i < 5; i++) {
         try {
-          logs = (
-            await getLogs({
-              target: target!,
-              topic: topic,
-              keys: [],
-              fromBlock: fromBlock,
-              toBlock: toBlock,
-              topics: topics as string[],
-              chain: overriddenChain,
-            })
-          ).output;
-          //console.log(logs)
+          logs = await getEventLogs({
+            target: target!,
+            topic: topic,
+            keys: [],
+            fromBlock: fromBlock,
+            toBlock: toBlock,
+            topics: topics as string[],
+            chain: overriddenChain,
+            noTarget: !target // set noTarget to true, if target is null
+          });
+
           if (logs.length === 0) {
             console.info(
               `No logs received for ${adapterName} from ${fromBlock} to ${toBlock} with topic ${topic} (${


### PR DESCRIPTION
Related to #393

This change replaces the old getLogs method with the new sdk.getLogs (v3) method as a drop-in replacement, requiring minimal changes.
If approved, I can work on integrating it into other parts of the codebase to fully leverage the SDK.

Tested with a few chains, and the results look consistent. For example:

```bash
npm run adapter 1753431500 1753439400 zksync
```