### PR TITLE
stargate: add Tempo Mainnet OFT spoke (USDC.e + EURC.e)

### DIFF
--- a/src/adapters/stargate/index.ts
+++ b/src/adapters/stargate/index.ts
@@ -549,6 +549,13 @@ const v2Addresses: Record<string, { token: string; pool: string }[]> = {
     { token: "0x19e26B0638bf63aa9fa4d14c6baF8D52eBE86C5C", pool: "0x77C71633C34C3784ede189d74223122422492a0f" }, // usdc
     { token: "0x9c2dc7377717603eB92b2655c5f2E7997a4945BD", pool: "0x1C10CC06DC6D35970d1D53B2A23c76ef370d4135" }, // usdt
   ],
+  // Tempo Mainnet "Presto" (chainId 4217) — Stargate v2 OFT spoke deployment.
+  // Mint-burn for inbound USDC.e/EURC.e from Ethereum Pool.
+  // Source: https://github.com/stargate-protocol/stargate-v2/tree/main/packages/stg-evm-v2/deployments/tempo-mainnet
+  tempo: [
+    { token: "0x20C000000000000000000000b9537d11c60E8b50", pool: "0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392" }, // usdc.e
+    { token: "0x20c0000000000000000000001621e21F71CF12fb", pool: "0x7753Dc8d4bd48Db599Da21E08b1Ab1D6FDFfdC71" }, // eurc.e
+  ],
   telos: [
     { token: "0xF1815bd50389c46847f0Bda824eC8da914045D14", pool: "0x2086f755A6d9254045C257ea3d382ef854849B0f" }, // usdc
     { token: "0x674843C06FF83502ddb4D37c2E09C01cdA38cbc8", pool: "0x3a1293Bdb83bBbDd5Ebf4fAc96605aD2021BbC0f" }, // usdt
@@ -775,6 +782,7 @@ const adapter: BridgeAdapter = {
   superposition: constructParams("spn"),
   taiko: constructParams("taiko"),
   telos: constructParams("telos"),
+  tempo: constructParams("tempo"),
   unichain: constructParams("unichain"),
   xchain: constructParams("idex"),
   xdc: constructParams("xdc"),

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -261,6 +261,7 @@ export default [
       "Superposition",
       "Taiko",
       "Telos",
+      "Tempo",
       "Unichain",
       "IDEX",
       "XDC",


### PR DESCRIPTION
## Summary

Adds Tempo Mainnet "Presto" (chainId 4217, launched 2026-03-18) to the Stargate adapter. Stargate v2 has deployed to Tempo as an **OFT spoke** (mint-burn) with USDC.e and EURC.e pools, plus TokenMessaging, CreditMessaging, FeeLib, OFTWrapper, and Treasurer — but DefiLlama bridges currently doesn't track any of this volume.

## Contracts

Verified via Stargate's official deployments repo at `stargate-v2/packages/stg-evm-v2/deployments/tempo-mainnet`:

| Token | Address | Pool (StargateOFT) |
|---|---|---|
| USDC.e | `0x20C0...b9537d11c60E8b50` | `0x8c76e2F6C5ceDA9AA7772e7efF30280226c44392` |
| EURC.e | `0x20c0...1621e21F71CF12fb` | `0x7753Dc8d4bd48Db599Da21E08b1Ab1D6FDFfdC71` |

Source: https://github.com/stargate-protocol/stargate-v2/tree/main/packages/stg-evm-v2/deployments/tempo-mainnet

## Pattern

Mint-burn / OFTSent / OFTReceived — the same pattern used by other OFT-spoke deployments already in the adapter (plasma, sei, sonic, soneium WETH). No code logic changes; just the new chain entry in `v2Addresses` + the `constructParams("tempo")` line + "Tempo" added to the chains array in `bridgeNetworkData.ts`.

## Local verification

\`\`\`
$ TEMPO_RPC=https://rpc.mainnet.tempo.xyz npm run test stargate 50000

Getting event logs on chain tempo from block 17473193 to 17523193.
Found 38 event logs on chain tempo.
[tempo] Withdrawal 0x8b0c0ddc08fde929821946044872eb3fb107e33058a66e4a56fb967b1250a568
[tempo] Withdrawal 0xbac4b3e7235e1fe56ad2ad53b98f164ef5f71d086205b35021c6e57e40ab9e67
[tempo] Deposit    0xd0c45bc2f59f410638cf655c3056b5479d502ac2fbaa7c05618a2865ccbf0853
... (38 total)
Values for event logs have correct types on chain tempo.
\`\`\`

Both inbound (Deposit) and outbound (Withdrawal) flows captured.

## Companion PRs

- [DefiLlama-Adapters #19015](https://github.com/DefiLlama/DefiLlama-Adapters/pull/19015) — Tempo TVL coverage (stable-dex refactor + Fee AMM TVL)
- [peggedassets-server #773](https://github.com/DefiLlama/peggedassets-server/pull/773) — pathUSD pegged + 9 stablecoin Tempo extends
- [dimension-adapters #6682](https://github.com/DefiLlama/dimension-adapters/pull/6682) — Fee AMM protocol fees adapter
- [defillama-sdk #214](https://github.com/DefiLlama/defillama-sdk/pull/214) — adds official Tempo RPC to providers.json

Together they give first-class Tempo Mainnet coverage across TVL, supply, fees, and bridge flow.
