### PR TITLE
fix(zksync): migrate ERC20 tracking from legacy bridge to L1NativeTokenVault (closes #481)

### DIFF
--- a/src/adapters/zksync/index.ts
+++ b/src/adapters/zksync/index.ts
@@ -2,21 +2,34 @@ import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeA
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 import { constructTransferParams } from "../../helpers/eventParams";
 
-/* 
+/*
 
 0x32400084C286CF3E17e7B677ea9583e60a000324 is zkSync Era: Diamond Proxy
-    - deposits of 
-        - ETH
-0xf8A16864D8De145A266a534174305f881ee2315e is zkSync Era: Withdrawal Finalizer
-0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063 is zkSync Era: Bridge
-    - deposits of 
-        - ERC20
-    - withdrawals of 
-        - ETH
-        - ERC20
+    - deposits of
+        - ETH (via NewPriorityRequest)
+    - withdrawals of
+        - ETH (via EthWithdrawalFinalized)
+
+0xbed1eb542f9a5aa6419ff3deb921a372681111f6 is the L1NativeTokenVault
+introduced with the v24 Bridgehub/SharedBridge upgrade — it now custodies
+ERC20s that used to sit on the legacy 0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063
+L1Erc20Bridge. The legacy bridge has stopped emitting events in production
+(0 in last 1000 blocks, vs ~46/1000 on the new shared bridge proxy
+0x8829ad80e425c646dab305381ff105169feece56 which forwards into the vault).
+ZKSync's own deprecation notice: zkSync-Community-Hub/zksync-developers#998.
+
+Tracking ERC20 deposits/withdrawals as Transfers to/from the vault keeps
+the same EventData shape and pricing path the legacy adapter used.
+
+0xf8A16864D8De145A266a534174305f881ee2315e (zkSync Era Withdrawal Finalizer)
+also stopped emitting (0 logs in last 1000 blocks) and is not used by the
+new path.
 */
 
 const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+// L1NativeTokenVault — custodies ERC20s bridged to ZKSync Era via the
+// post-v24 SharedBridge architecture.
+const ZKSYNC_ERA_L1_VAULT = "0xbed1eb542f9a5aa6419ff3deb921a372681111f6";
 
 const ethDepositEventParams: PartialContractEventParams = {
   target: "0x32400084C286CF3E17e7B677ea9583e60a000324",
@@ -48,7 +61,7 @@ const ethDepositEventParams: PartialContractEventParams = {
 };
 
 const erc20DepositEventParams: PartialContractEventParams = constructTransferParams(
-  "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
+  ZKSYNC_ERA_L1_VAULT,
   true
 );
 
@@ -68,7 +81,7 @@ const ethWithdrawalEventParams: PartialContractEventParams = {
 };
 
 const erc20WithdrawalEventParams: PartialContractEventParams = constructTransferParams(
-  "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
+  ZKSYNC_ERA_L1_VAULT,
   false
 );
 


### PR DESCRIPTION
Closes #481.

## Problem

[jcsec-security flagged in #481](https://github.com/DefiLlama/bridges-server/issues/481) that this adapter still points at the legacy `L1Erc20Bridge` (`0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063`). ZKSync's own deprecation notice [zkSync-Community-Hub/zksync-developers#998](https://github.com/zkSync-Community-Hub/zksync-developers/discussions/998) called the deprecation window over and announced the v24 Bridgehub / SharedBridge as the replacement.

## Verification

The legacy bridge has already stopped emitting events on mainnet:

| Address | Role | Logs in last 1000 blocks |
|---|---|---:|
| `0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063` | Legacy `L1Erc20Bridge` | **0** |
| `0xf8A16864D8De145A266a534174305f881ee2315e` | Legacy `Withdrawal Finalizer` | **0** |
| `0x32400084C286CF3E17e7B677ea9583e60a000324` | Diamond Proxy (ETH path) | 38 |
| `0x8829ad80e425c646dab305381ff105169feece56` | New `L1AssetRouter` proxy | 46 |

So ERC20 deposits/withdrawals are currently going entirely untracked on the DefiLlama side, while ETH (Diamond Proxy `NewPriorityRequest` / `EthWithdrawalFinalized`) is unaffected and keeps working.

## What this PR does

Repoints the ERC20 transfer-based deposit and withdrawal params from the legacy bridge to the new **`L1NativeTokenVault`** at `0xbed1eb542f9a5aa6419ff3deb921a372681111f6`, which now custodies ERC20s under the v24 architecture. The framework's `constructTransferParams(target, isDeposit)` shape is unchanged.

Verified by tracing five recent `BridgehubDepositInitiated` transactions (`0x09931...`, `0x0eecf...`, `0x1333c...`, `0x15fdd...`, `0x17d1a...`): every one emits an ERC20 `Transfer` event with the deposit token (USDC, USDT, etc.) and the vault as the recipient, exactly the shape `constructTransferParams` consumes.

## What this PR does NOT touch

- **ETH deposit** (Diamond Proxy `NewPriorityRequest`) — still emitted on every ETH deposit, including ones that also emit the new bridge's `BridgehubDepositBaseTokenInitiated` (confirmed via tx `0x6eca2c6...`). Listening on both would double-count.
- **ETH withdrawal** (Diamond Proxy `EthWithdrawalFinalized`) — left as-is. We can revisit if it stops emitting.

## Diff

1 file, +25 / -12.

\`\`\`diff
- "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",   // legacy bridge
+ ZKSYNC_ERA_L1_VAULT,                            // 0xbed1eb...111f6
\`\`\`

plus an updated block comment documenting the new architecture and citing ZKSync's deprecation notice.