### PR TITLE
fix(axelar): use chainName for token lookup in InterchainTransferReceived

### DIFF
--- a/src/adapters/axelar/index.ts
+++ b/src/adapters/axelar/index.ts
@@ -332,7 +332,7 @@ const constructParams = (chain: SupportedChains) => {
           const asset = itsAssets.find((item: any) => item.id.toLowerCase() === log.tokenId.toLowerCase());
           const chainName = chain === "avax" ? "avalanche" : chain;
           return asset && asset.chains && asset.chains[chainName] && asset.chains[chainName].tokenAddress
-            ? asset.chains[chain].tokenAddress
+            ? asset.chains[chainName].tokenAddress
             : "";
         },
       },


### PR DESCRIPTION
## Summary

[PR #370](https://github.com/DefiLlama/bridges-server/pull/370) normalized the Avalanche chain key (`avax` → `avalanche`) when looking up Axelar ITS asset metadata, but only half-applied the change to the `InterchainTransferReceived` handler — the existence check uses `chainName`, the return path still uses `chain`. On Avalanche this throws a `TypeError` which `getTxDataFromEVMEventLogs`' inner `try/catch` swallows, silently dropping every Avalanche-inbound ITS transfer from bridge volume.

```diff
           return asset && asset.chains && asset.chains[chainName] && asset.chains[chainName].tokenAddress
-            ? asset.chains[chain].tokenAddress
+            ? asset.chains[chainName].tokenAddress
             : "";
```

## Verification

**1. Code path:** The adapter registers Avalanche as `avalanche: constructParams("avax")` ([line 356](https://github.com/DefiLlama/bridges-server/blob/master/src/adapters/axelar/index.ts#L356)), so the closure runs with `chain === "avax"`.

**2. Live API data:** The Axelar ITS asset listing (`https://api.axelarscan.io/api/getITSAssets`) keys assets by `avalanche`, never `avax`:

```js
> chains keys for asset 0x3142...c15a67:
['avalanche', 'base', 'binance', 'optimism']
> asset.chains['avalanche'].tokenAddress
'0xe19A1684873faB5Fb694CfD06607100A632fF21c'
> asset.chains['avax']
undefined
```

**3. Executable repro** of the buggy handler against live API data:

```
--- SENT handler (uses chainName, works) ---
OK, returned: 0xe19A1684873faB5Fb694CfD06607100A632fF21c

--- RECEIVED handler at HEAD (uses chain, current code) ---
THREW: Cannot read properties of undefined (reading 'tokenAddress')
```

**4. On-chain example currently being dropped:** Avalanche tx [`0x50baa33a...e420a40e4fb`](https://snowtrace.io/tx/0x50baa33aaaff9a4984dc01aa6d400c8c2be7cb0a2e5a5b05dd35fe420a40e4fb) emits `InterchainTransferReceived` from the ITS contract `0xB5FB4BE0...80dE9e3C` at block 85742068. With the current code the `argGetters.token` resolver throws and `processTransactions.ts`' inner catch silently `return`s, dropping the entire transaction from bridge volume.

## Fix

One-line change to line 335 of `src/adapters/axelar/index.ts` — bring the return path in line with the existence check and with the `InterchainTransferSent` sibling handler ([line 318](https://github.com/DefiLlama/bridges-server/blob/master/src/adapters/axelar/index.ts#L318)).

## Test plan

- [x] `tsc --noEmit` — only pre-existing unrelated `runAdapterHistorical.ts` warning
- [x] `npm run test axelar 100` — adapter still loads and runs all chains
- [ ] After merge, Avalanche-inbound ITS transfers should appear in `bridges.transactions` again