### PR TITLE
fix(starkgate): switch deposit event to upgraded Deposit signature

### DIFF
--- a/src/adapters/starkgate/index.ts
+++ b/src/adapters/starkgate/index.ts
@@ -12,7 +12,12 @@ Contract Addresses:
 - ERC20 Bridge (USDC, USDT, DAI, WBTC, etc): Various token-specific bridges
 
 Events:
-- LogDeposit: Triggered when tokens are deposited from L1 to L2
+- Deposit: Triggered when tokens are deposited from L1 to L2. The StarkGate
+  proxy implementations were upgraded in Feb 2025 and now emit the
+  six-arg Deposit event (with an indexed `token` field) rather than
+  the legacy five-arg LogDeposit. Verified on the live STRK, USDT,
+  ETH and wstETH bridges; the legacy LogDeposit topic is silent on
+  every sub-bridge except for a 4% tail on the ETH bridge.
 - LogMessageToL1: Triggered when tokens are withdrawn from L2(StarkNet Core) to L1
 */
 
@@ -58,12 +63,16 @@ const tokenAddresses: { [key: string]: string } = {
   fxs: "0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0",
 };
 
-// Deposit event for ERC20 tokens
+// Deposit event for ERC20 tokens.
+// The post-upgrade implementation indexes a `token` arg in topic2, but for
+// every sub-bridge it equals the L1 ERC20 we already track per-contract, so
+// we keep `fixedEventData.token` (matches the ETH bridge sentinel handling
+// below and stays drop-in compatible with the historical adapter shape).
 const erc20DepositParams = (contractAddress: string, tokenAddress: string): PartialContractEventParams => ({
   target: contractAddress,
-  topic: "LogDeposit(address,uint256,uint256,uint256,uint256)",
+  topic: "Deposit(address,address,uint256,uint256,uint256,uint256)",
   abi: [
-    "event LogDeposit(address indexed sender, uint256 amount, uint256 indexed l2Recipient, uint256 nonce, uint256 fee)",
+    "event Deposit(address indexed sender, address indexed token, uint256 amount, uint256 indexed l2Recipient, uint256 nonce, uint256 fee)",
   ],
   logKeys: {
     blockNumber: "blockNumber",
@@ -117,12 +126,16 @@ const erc20WithdrawalParams = (
   isDeposit: false,
 });
 
-// ETH-specific events
+// ETH-specific events.
+// The ETH bridge emits the same Deposit signature, but its indexed `token`
+// arg is the on-chain sentinel 0x0000000000000000000000000000000000455448
+// (ASCII "ETH") rather than a real ERC20. We override with WETH so the
+// downstream pricing layer can value it.
 const ethDepositParams: PartialContractEventParams = {
   target: ethBridgeContract,
-  topic: "LogDeposit(address,uint256,uint256,uint256,uint256)",
+  topic: "Deposit(address,address,uint256,uint256,uint256,uint256)",
   abi: [
-    "event LogDeposit(address indexed sender, uint256 amount, uint256 indexed l2Recipient, uint256 nonce, uint256 fee)",
+    "event Deposit(address indexed sender, address indexed token, uint256 amount, uint256 indexed l2Recipient, uint256 nonce, uint256 fee)",
   ],
   logKeys: {
     blockNumber: "blockNumber",


### PR DESCRIPTION
StarkGate's proxy implementations were upgraded in Feb 2025 (impl `0xa72a8F31163d74d708664493d09167dfa13008E9`, deployed block 21,771,817). The current adapter — added in #436, Nov 2025 — still filters deposits on the legacy five-arg `LogDeposit` signature, so `getLogs` returns essentially nothing and StarkGate deposit volume is effectively untracked on Ethereum.

## What the post-upgrade event looks like

```solidity
event Deposit(
  address indexed sender,
  address indexed token,
  uint256 amount,
  uint256 indexed l2Recipient,
  uint256 nonce,
  uint256 fee
)
// topic[0] = 0x5f971bd00bf3ffbca8a6d72cdd4fd92cfd4f62636161921d1e5a64f0b64ccb6d
```

Hash verified two ways: locally via `keccak256(...)` and cross-checked against [openchain.xyz signature DB](https://api.openchain.xyz/signature-database/v1/lookup?event=0x5f971bd00bf3ffbca8a6d72cdd4fd92cfd4f62636161921d1e5a64f0b64ccb6d&filter=true).

## On-chain evidence

Walked all 14 sub-bridges across the last 49,000 blocks (~7 days, head 25,131,221):

| Bridge | Address | `LogDeposit` (legacy) | `Deposit` (post-upgrade) |
|---|---|---:|---:|
| STRK | `0xce5485Cfb26914C5dCE00B9BAF0580364DafC7a4` | 0 | **21** |
| ETH | `0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419` | 2 | **46** |
| USDT | `0xbb3400F107804DFB482565FF1Ec8D8aE66747605` | 0 | **54** |
| wstETH | `0xBf67F59D2988A46FBFF7ed79A621778a3Cd3985B` | 0 | **1** |
| USDC, WBTC, DAI, rETH, sfrxETH, UNI, FRAX, FXS, LUSD, R | (10 bridges) | 0 | 0 |

122 new-topic deposits vs 2 legacy on the active bridges → the adapter currently catches < 2 % of real activity. The 2 legacy events on the ETH bridge include one 142 ETH deposit, so even the tail isn't trivial.

Spot-check txs (you can paste any of these into Etherscan to see the event format):

- STRK: `0xda17c7b405c555524ba677a87b7093a7da6f63a76da07e53db6b49de8cfc4422`
- USDT: `0xf9331d12d074d67a67455fcafd34ee7175d3f4c88b6f07e100c4346d51c8ed51`
- ETH:  `0x8c1136e31755e6f77a84e68f38c04cac1eb9a28948fe1da24572dfd35cc69041`

## ETH bridge — `token` field detail

The ETH bridge fills the new event's indexed `token` arg with the on-chain sentinel `0x0000000000000000000000000000000000455448` (ASCII "ETH"), not a real ERC20. ERC20 bridges fill it with the canonical L1 token address (verified on USDT, STRK). I kept `fixedEventData.token = WETH` for the ETH bridge so the pricing layer can value it, and `fixedEventData.token = <L1 ERC20>` for every other bridge — same shape as the existing adapter, no token-mapping changes needed.

## Withdrawal side

`LogMessageToL1` on StarkNet Core (`0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4`) is untouched — verified 152 events in the same 49k-block window with the same payload layout, so the existing withdrawal params are still correct.

## Diff

`+20 / -7` in one file. Two topic strings, two ABI strings, and the comment block. The 10 currently-dormant sub-bridges share the upgraded implementation, so this is forward-compatible if they wake up.

## Test plan

- [x] `npm run ts` clean (one pre-existing unused-var warning in `runAdapterHistorical.ts:151`, not from this PR)
- [x] Topic hash verified locally via keccak + cross-checked on openchain.xyz signature DB
- [x] All 14 sub-bridge contracts queried for both legacy and new topics over 49k blocks
- [x] Sample logs decoded to confirm event field order (sender, token, amount, l2Recipient, nonce, fee)
- [x] Withdrawal path verified still firing