### PR TITLE
feat: add WavesBridge adapter

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -107,6 +107,7 @@ import clementine from "./clementine";
 import citreaUsdc from "./citrea-usdc";
 import citreaUsdt from "./citrea-usdt";
 import citreaWbtc from "./citrea-wbtc";
+import wavesbridge from "./wavesbridge";
 
 export default {
   polygon,
@@ -217,6 +218,7 @@ export default {
   "citrea-usdc": citreaUsdc,
   "citrea-usdt": citreaUsdt,
   "citrea-wbtc": citreaWbtc,
+  wavesbridge,
 } as {
   [bridge: string]: BridgeAdapter | AsyncBridgeAdapter;
 };

--- a/src/adapters/wavesbridge/index.ts
+++ b/src/adapters/wavesbridge/index.ts
@@ -1,0 +1,65 @@
+import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeAdapter.type";
+import { Chain } from "@defillama/sdk/build/general";
+import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
+
+const BRIDGE = "0x3AC7A6635d99F376c3c05442f7Eef62d349C3A55";
+
+const depositParams: PartialContractEventParams = {
+    target: BRIDGE,
+    topic: "Sent(bytes4,bytes32,address,bytes32,uint256,uint128,bytes4)",
+    abi: [
+        "event Sent(bytes4 tokenSource, bytes32 tokenSourceAddress, address sender, bytes32 indexed recipient, uint256 amount, uint128 indexed lockId, bytes4 destination)",
+    ],
+    logKeys: {
+        blockNumber: "blockNumber",
+        txHash: "transactionHash",
+    },
+    argKeys: {
+        from: "sender",
+        amount: "amount",
+    },
+    fixedEventData: {
+        to: BRIDGE,
+    },
+    isDeposit: true,
+    getTokenFromReceipt: {
+        token: true,
+        amount: false,
+    },
+};
+
+const withdrawalParams: PartialContractEventParams = {
+    target: BRIDGE,
+    topic: "Received(address,address,uint256,uint128,bytes4)",
+    abi: [
+        "event Received(address indexed recipient, address token, uint256 amount, uint128 indexed lockId, bytes4 source)",
+    ],
+    logKeys: {
+        blockNumber: "blockNumber",
+        txHash: "transactionHash",
+    },
+    argKeys: {
+        to: "recipient",
+        token: "token",
+        amount: "amount",
+    },
+    fixedEventData: {
+        from: BRIDGE,
+    },
+    isDeposit: false,
+};
+
+const constructParams = (chain: string) => {
+    return async (fromBlock: number, toBlock: number) =>
+        getTxDataFromEVMEventLogs("wavesbridge", chain as Chain, fromBlock, toBlock, [
+            depositParams,
+            withdrawalParams,
+        ]);
+};
+
+const adapter: BridgeAdapter = {
+    ethereum: constructParams("ethereum"),
+    bsc: constructParams("bsc"),
+};
+
+export default adapter;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -2952,4 +2952,14 @@ export default [
     url: "https://citrea.xyz/",
     chains: ["Ethereum", "Citrea"],
   },
+  {
+    id: 112,
+    displayName: "WavesBridge",
+    bridgeDbName: "wavesbridge",
+    iconLink: "icons:wavesbridge",
+    largeTxThreshold: 10000,
+    url: "https://wavesbridge.io/",
+    chains: ["Ethereum", "BSC"],
+    destinationChain: "Waves",
+  },
 ] as BridgeNetwork[];


### PR DESCRIPTION
Add adapter for [WavesBridge](https://wavesbridge.io/), a cross-chain bridge connecting the Waves/Unit0 ecosystem to EVM chains (Ethereum, BSC).

## Changes
- New adapter `src/adapters/wavesbridge/index.ts`
- Tracks `Sent` (deposit/lock) and `Received` (withdrawal/unlock) events on the Bridge contract `0x3AC7A6635d99F376c3c05442f7Eef62d349C3A55`
- Registered in `bridgeNetworkData.ts` with id 112

## Contract
The same Bridge contract address is deployed on both Ethereum and BSC. Uses token receipt parsing for deposit amounts and direct event args for withdrawals.