### PR TITLE
Batch 24h volume query in /bridges to reduce DB round-trips

### DIFF
--- a/src/handlers/getBridges.ts
+++ b/src/handlers/getBridges.ts
@@ -5,82 +5,80 @@ import { craftBridgeChainsResponse } from "./getBridgeChains";
 import { secondsInDay, getCurrentUnixTimestamp, getTimestampAtStartOfDay } from "../utils/date";
 import bridgeNetworks from "../data/bridgeNetworkData";
 import { normalizeChain, getChainDisplayName } from "../utils/normalizeChain";
-import { getLast24HVolume } from "../utils/wrappa/postgres/query";
+import { getAllLast24HVolumes } from "../utils/wrappa/postgres/query";
 
 const getBridges = async () => {
-  const response = (
-    await Promise.all(
-      bridgeNetworks.map(async (bridgeNetwork) => {
-        const { id, bridgeDbName, url, displayName, iconLink, chains, destinationChain, slug, defillamaId, } = bridgeNetwork;
-        // can use chains to give chain breakdown, but not needed at this time (put in getBridge to reduce queries?)
+  const startOfTheDayTs = getTimestampAtStartOfDay(getCurrentUnixTimestamp());
+  const dailyStartTimestamp = startOfTheDayTs - 30 * secondsInDay;
 
-        let lastHourlyVolume, lastDailyVolume, dayBeforeLastVolume;
-        let weeklyVolume = 0;
-        let monthlyVolume = 0;
-        const startOfTheDayTs = getTimestampAtStartOfDay(getCurrentUnixTimestamp());
-        const dailyStartTimestamp = startOfTheDayTs - 30 * secondsInDay;
-        const [lastMonthDailyVolume, last24hVolume] = await Promise.all([
-          getDailyBridgeVolume(dailyStartTimestamp, startOfTheDayTs, undefined, id),
-          getLast24HVolume(bridgeDbName),
-        ]);
+  const [all24hVolumes, ...allMonthlyVolumes] = await Promise.all([
+    getAllLast24HVolumes(),
+    ...bridgeNetworks.map(({ id }) => getDailyBridgeVolume(dailyStartTimestamp, startOfTheDayTs, undefined, id)),
+  ]);
 
-        let lastDailyTs = 0;
-        if (lastMonthDailyVolume?.length) {
-          const lastDailyVolumeRecord = lastMonthDailyVolume[lastMonthDailyVolume.length - 1];
-          lastDailyTs = parseInt(lastDailyVolumeRecord.date);
-          const lastDeposit = Number.isFinite(lastDailyVolumeRecord.depositUSD) ? lastDailyVolumeRecord.depositUSD : 0;
-          const lastWithdraw = Number.isFinite(lastDailyVolumeRecord.withdrawUSD) ? lastDailyVolumeRecord.withdrawUSD : 0;
-          lastDailyVolume = (lastDeposit + lastWithdraw) / 2;
+  const response = bridgeNetworks
+    .map((bridgeNetwork, i) => {
+      const { id, bridgeDbName, url, displayName, iconLink, chains, destinationChain, slug, defillamaId } =
+        bridgeNetwork;
 
-          const dayBeforeLastVolumeRecord = lastMonthDailyVolume[lastMonthDailyVolume.length - 2];
-          if (dayBeforeLastVolumeRecord && Object.keys(dayBeforeLastVolumeRecord).length > 0) {
-            const prevDeposit = Number.isFinite(dayBeforeLastVolumeRecord.depositUSD) ? dayBeforeLastVolumeRecord.depositUSD : 0;
-            const prevWithdraw = Number.isFinite(dayBeforeLastVolumeRecord.withdrawUSD) ? dayBeforeLastVolumeRecord.withdrawUSD : 0;
-            dayBeforeLastVolume = (prevDeposit + prevWithdraw) / 2;
-          }
-          lastMonthDailyVolume.map((entry: any, i: number) => {
-            const depositUSD = Number.isFinite(entry.depositUSD) ? entry.depositUSD : 0;
-            const withdrawUSD = Number.isFinite(entry.withdrawUSD) ? entry.withdrawUSD : 0;
-            const volume = (depositUSD + withdrawUSD) / 2;
-            monthlyVolume += volume;
-            if (i > lastMonthDailyVolume.length - 8) {
-              weeklyVolume += volume;
-            }
-          });
+      const last24hVolume = all24hVolumes[bridgeDbName] ?? 0;
+      const lastMonthDailyVolume = allMonthlyVolumes[i];
+
+      let lastDailyVolume = 0;
+      let dayBeforeLastVolume = 0;
+      let weeklyVolume = 0;
+      let monthlyVolume = 0;
+
+      if (lastMonthDailyVolume?.length) {
+        const lastRecord = lastMonthDailyVolume[lastMonthDailyVolume.length - 1];
+        const lastDeposit = Number.isFinite(lastRecord.depositUSD) ? lastRecord.depositUSD : 0;
+        const lastWithdraw = Number.isFinite(lastRecord.withdrawUSD) ? lastRecord.withdrawUSD : 0;
+        lastDailyVolume = (lastDeposit + lastWithdraw) / 2;
+
+        const prevRecord = lastMonthDailyVolume[lastMonthDailyVolume.length - 2];
+        if (prevRecord && Object.keys(prevRecord).length > 0) {
+          const prevDeposit = Number.isFinite(prevRecord.depositUSD) ? prevRecord.depositUSD : 0;
+          const prevWithdraw = Number.isFinite(prevRecord.withdrawUSD) ? prevRecord.withdrawUSD : 0;
+          dayBeforeLastVolume = (prevDeposit + prevWithdraw) / 2;
         }
 
-        // can include transaction count if needed
-        const normalizedChains = (chains || []).map((c) =>
-          getChainDisplayName(normalizeChain(c), true)
-        );
-        const destinationChainDisplay = destinationChain
-          ? getChainDisplayName(normalizeChain(destinationChain), true)
-          : "false";
-        const dataToReturn = {
-          id: id,
-          defillamaId,
-          name: bridgeDbName,
-          displayName: displayName,
-          // url: url,
-          icon: iconLink,
-          volumePrevDay: last24hVolume ?? 0,
-          volumePrev2Day: dayBeforeLastVolume ?? 0,
-          lastHourlyVolume: lastHourlyVolume ?? 0,
-          last24hVolume: last24hVolume ?? 0,
-          lastDailyVolume: last24hVolume ?? 0,
-          dayBeforeLastVolume: dayBeforeLastVolume ?? 0,
-          weeklyVolume: weeklyVolume ?? 0,
-          monthlyVolume: monthlyVolume ?? 0,
-          chains: normalizedChains,
-          destinationChain: destinationChainDisplay,
-          url,
-          slug,
-        } as any;
-        return dataToReturn;
-      })
-    )
-  )
-    .filter((bridgeNetwork) => bridgeNetwork !== null)
+        lastMonthDailyVolume.forEach((entry: any, i: number) => {
+          const depositUSD = Number.isFinite(entry.depositUSD) ? entry.depositUSD : 0;
+          const withdrawUSD = Number.isFinite(entry.withdrawUSD) ? entry.withdrawUSD : 0;
+          const volume = (depositUSD + withdrawUSD) / 2;
+          monthlyVolume += volume;
+          if (i > lastMonthDailyVolume.length - 8) {
+            weeklyVolume += volume;
+          }
+        });
+      }
+
+      const normalizedChains = (chains || []).map((c) => getChainDisplayName(normalizeChain(c), true));
+      const destinationChainDisplay = destinationChain
+        ? getChainDisplayName(normalizeChain(destinationChain), true)
+        : "false";
+
+      return {
+        id,
+        defillamaId,
+        name: bridgeDbName,
+        displayName,
+        icon: iconLink,
+        volumePrevDay: last24hVolume,
+        volumePrev2Day: dayBeforeLastVolume,
+        lastHourlyVolume: 0,
+        last24hVolume,
+        lastDailyVolume: last24hVolume,
+        dayBeforeLastVolume,
+        weeklyVolume,
+        monthlyVolume,
+        chains: normalizedChains,
+        destinationChain: destinationChainDisplay,
+        url,
+        slug,
+      };
+    })
+    .filter((b) => b !== null)
     .sort((a, b) => b.lastDailyVolume - a.lastDailyVolume);
 
   return response;
@@ -93,9 +91,7 @@ const handler = async (event: AWSLambda.APIGatewayEvent): Promise<IResponse> => 
     promises.push(craftBridgeChainsResponse());
   }
   const [bridges, chainData] = await Promise.all(promises);
-  let response: any = {
-    bridges: bridges,
-  };
+  let response: any = { bridges };
   if (includeChains) {
     response.chains = chainData;
   }

--- a/src/utils/wrappa/postgres/query.ts
+++ b/src/utils/wrappa/postgres/query.ts
@@ -387,6 +387,47 @@ const getLast24HVolume = async (bridgeName: string, volumeType: VolumeType = "bo
   return totalVolume / 2;
 };
 
+const getAllLast24HVolumes = async (): Promise<Record<string, number>> => {
+  const WORMHOLE_HOURS = 28;
+  const DEFAULT_HOURS = 24;
+
+  const result = await sql<{ bridge_name: string; volume: string }[]>`
+    WITH per_bridge_latest AS (
+      SELECT
+        c.bridge_name,
+        MAX(ha.ts) AS max_ts
+      FROM bridges.hourly_volume ha
+      JOIN bridges.config c ON ha.bridge_id = c.id
+      GROUP BY c.bridge_name
+    ),
+    per_bridge_rows AS (
+      SELECT
+        c.bridge_name,
+        (ha.total_deposited_usd + ha.total_withdrawn_usd) AS volume,
+        c.chain
+      FROM bridges.hourly_volume ha
+      JOIN bridges.config c ON ha.bridge_id = c.id
+      JOIN per_bridge_latest pbl ON c.bridge_name = pbl.bridge_name
+      WHERE ha.ts > pbl.max_ts - make_interval(
+        hours => CASE WHEN c.bridge_name = 'wormhole' THEN ${WORMHOLE_HOURS} ELSE ${DEFAULT_HOURS} END
+      )
+    ),
+    per_bridge_chain AS (
+      SELECT bridge_name, chain, SUM(volume) AS chain_volume
+      FROM per_bridge_rows
+      GROUP BY bridge_name, chain
+    )
+    SELECT bridge_name, (SUM(chain_volume) / 2)::text AS volume
+    FROM per_bridge_chain
+    GROUP BY bridge_name
+  `;
+
+  return result.reduce((acc, { bridge_name, volume }) => {
+    acc[bridge_name] = parseFloat(volume) || 0;
+    return acc;
+  }, {} as Record<string, number>);
+};
+
 const queryBridgeTxCounts24h = async (chain?: string) => {
   if (!chain) {
     return await sql<IBridgeTxCounts24H[]>`
@@ -747,6 +788,7 @@ export {
   queryAggregatedDailyTimestampRange,
   queryAggregatedHourlyTimestampRange,
   getLast24HVolume,
+  getAllLast24HVolumes,
   queryBridgeTxCounts24h,
   getNetflows,
   queryAggregatedTokenStatsTop30,


### PR DESCRIPTION
The /bridges endpoint was issuing one getLast24HVolume query per bridge network alongside one getDailyBridgeVolume query per bridge, hence totalling 2N DB queries fired inside a promise.all. For ~100 registered bridges this was putting significant concurrent load on the DB on every request.

Added getAllLast24HVolumes() which fetches 24h volume for all bridges in a single SQL query using GROUP BY bridge_name, then maps results by bridge name in memory. The monthly volume queries (getDailyBridgeVolume) remain parallel as before. Response shape is unchanged.