### PR TITLE
Add /stale-bridges, /bridge-search, and /netflows/compare endpoints

### DIFF
--- a/src/handlers/getNetflowsCompare.ts
+++ b/src/handlers/getNetflowsCompare.ts
@@ -1,0 +1,73 @@
+import { IResponse, successResponse, errorResponse } from "../utils/lambda-response";
+import wrap from "../utils/wrap";
+import { getNetflows } from "../utils/wrappa/postgres/query";
+import { normalizeChain, getChainDisplayName } from "../utils/normalizeChain";
+
+const MAX_CHAINS = 10;
+
+type Period = "day" | "week" | "month";
+
+const handler = async (event: AWSLambda.APIGatewayEvent): Promise<IResponse> => {
+  const period = event.queryStringParameters?.period?.toLowerCase() as Period;
+  const chainsParam = event.queryStringParameters?.chains;
+
+  if (!period || !["day", "week", "month"].includes(period)) {
+    return errorResponse({ message: "period must be one of: day, week, month" });
+  }
+
+  if (!chainsParam) {
+    return errorResponse({ message: "chains parameter is required (comma-separated list)" });
+  }
+
+  const requestedChains = chainsParam
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean)
+    .slice(0, MAX_CHAINS);
+
+  if (requestedChains.length === 0) {
+    return errorResponse({ message: "at least one chain is required" });
+  }
+
+  const normalizedRequested = requestedChains.map((c) => normalizeChain(c));
+
+  const raw = await getNetflows(period);
+
+  const merged = new Map<string, { chain: string; net_flow: number; deposited_usd: number; withdrawn_usd: number }>();
+  for (const row of raw) {
+    const name = getChainDisplayName(normalizeChain(row.chain), true);
+    const normalized = normalizeChain(row.chain);
+    const prev = merged.get(normalized);
+    const net = parseFloat(row.net_flow ?? "0");
+    const dep = parseFloat(row.deposited_usd ?? "0");
+    const wdr = parseFloat(row.withdrawn_usd ?? "0");
+    if (!prev) {
+      merged.set(normalized, { chain: name, net_flow: net, deposited_usd: dep, withdrawn_usd: wdr });
+    } else {
+      prev.net_flow += net;
+      prev.deposited_usd += dep;
+      prev.withdrawn_usd += wdr;
+    }
+  }
+
+  const missing: string[] = [];
+  const results = normalizedRequested.map((normalized, i) => {
+    const data = merged.get(normalized);
+    if (!data) {
+      missing.push(requestedChains[i]);
+      return { chain: getChainDisplayName(normalized, true), net_flow: null, deposited_usd: null, withdrawn_usd: null };
+    }
+    return data;
+  });
+
+  return successResponse(
+    {
+      period,
+      chains: results,
+      ...(missing.length > 0 ? { missing } : {}),
+    },
+    10 * 60
+  );
+};
+
+export default wrap(handler);

--- a/src/handlers/getStaleBridges.ts
+++ b/src/handlers/getStaleBridges.ts
@@ -1,0 +1,68 @@
+import { IResponse, successResponse } from "../utils/lambda-response";
+import wrap from "../utils/wrap";
+import bridgeNetworks from "../data/bridgeNetworkData";
+import { queryAggregatedDailyTimestampRange } from "../utils/wrappa/postgres/query";
+
+const STALE_THRESHOLD_DAYS = 3;
+
+const getStaleBridges = async () => {
+  const startTs = Math.floor(Date.now() / 1000 - 60 * 60 * 24 * 7);
+  const endTs = Math.floor(Date.now() / 1000);
+  const currentDate = new Date();
+
+  const queries = bridgeNetworks.flatMap((bridge) =>
+    bridge.chains
+      .filter((chain) => bridge.destinationChain !== chain)
+      .map(async (chain) => {
+        try {
+          const volume = await queryAggregatedDailyTimestampRange(
+            startTs,
+            endTs,
+            chain.toLowerCase(),
+            bridge.bridgeDbName
+          );
+
+          let staleDays = 7;
+          if (volume.length > 0) {
+            let lastActiveDay = new Date(0);
+            for (const day of volume) {
+              if (day.total_deposit_txs > 0 || day.total_withdrawal_txs > 0) {
+                lastActiveDay = new Date(day.ts);
+              }
+            }
+            staleDays =
+              lastActiveDay.getTime() === 0
+                ? 7
+                : Math.floor((currentDate.getTime() - lastActiveDay.getTime()) / (1000 * 3600 * 24));
+          }
+
+          return { bridge: bridge.bridgeDbName, chain, staleDays };
+        } catch {
+          return { bridge: bridge.bridgeDbName, chain, staleDays: -1 };
+        }
+      })
+  );
+
+  const results = await Promise.all(queries);
+
+  const stale = results.filter((r) => r.staleDays >= STALE_THRESHOLD_DAYS);
+
+  const byBridge: Record<string, { chain: string; staleDays: number }[]> = {};
+  for (const { bridge, chain, staleDays } of stale) {
+    if (!byBridge[bridge]) byBridge[bridge] = [];
+    byBridge[bridge].push({ chain, staleDays });
+  }
+
+  return {
+    thresholdDays: STALE_THRESHOLD_DAYS,
+    staleCount: stale.length,
+    bridges: byBridge,
+  };
+};
+
+const handler = async (_event: AWSLambda.APIGatewayEvent): Promise<IResponse> => {
+  const response = await getStaleBridges();
+  return successResponse(response, 30 * 60); // 30 min cache
+};
+
+export default wrap(handler);

--- a/src/handlers/searchBridges.ts
+++ b/src/handlers/searchBridges.ts
@@ -1,0 +1,45 @@
+import { IResponse, successResponse, errorResponse } from "../utils/lambda-response";
+import wrap from "../utils/wrap";
+import bridgeNetworks from "../data/bridgeNetworkData";
+import { normalizeChain, getChainDisplayName } from "../utils/normalizeChain";
+
+const searchBridges = (query?: string, chain?: string) => {
+  const q = query?.toLowerCase().trim();
+  const normalizedChainFilter = chain ? normalizeChain(chain) : undefined;
+
+  const results = bridgeNetworks.filter((bridge) => {
+    const matchesQuery = q
+      ? bridge.displayName.toLowerCase().includes(q) || bridge.bridgeDbName.toLowerCase().includes(q)
+      : true;
+
+    const matchesChain = normalizedChainFilter
+      ? bridge.chains.some((c) => normalizeChain(c) === normalizedChainFilter)
+      : true;
+
+    return matchesQuery && matchesChain;
+  });
+
+  return results.map((bridge) => ({
+    id: bridge.id,
+    name: bridge.bridgeDbName,
+    displayName: bridge.displayName,
+    icon: bridge.iconLink,
+    url: bridge.url,
+    slug: bridge.slug,
+    chains: bridge.chains.map((c) => getChainDisplayName(normalizeChain(c), true)),
+  }));
+};
+
+const handler = async (event: AWSLambda.APIGatewayEvent): Promise<IResponse> => {
+  const query = event.queryStringParameters?.q;
+  const chain = event.queryStringParameters?.chain;
+
+  if (!query && !chain) {
+    return errorResponse({ message: "At least one of q or chain query parameters is required." });
+  }
+
+  const results = searchBridges(query, chain);
+  return successResponse(results, 10 * 60); // 10 min cache
+};
+
+export default wrap(handler);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,9 @@ import getNetflows from "../handlers/getNetflows";
 import getTransactions from "../handlers/getTransactions";
 import runAdapter from "../handlers/runAdapter";
 import getBridgeStatsOnDay from "../handlers/getBridgeStatsOnDay";
+import getStaleBridges from "../handlers/getStaleBridges";
+import searchBridges from "../handlers/searchBridges";
+import getNetflowsCompare from "../handlers/getNetflowsCompare";
 import getTopGetLogs from "../handlers/getTopGetLogs";
 import { generateApiCacheKey, registerCacheHandler, warmCache, needsWarming, setCache, getCache } from "../utils/cache";
 import { startHealthMonitoring, getHealthStatus } from "./health";
@@ -176,6 +179,9 @@ const start = async () => {
     server.get("/transactions/:id", lambdaToFastify(getTransactions));
     server.post("/run-adapter", lambdaToFastify(runAdapter));
     server.get("/top-getlogs", lambdaToFastify(getTopGetLogs));
+    server.get("/stale-bridges", lambdaToFastify(getStaleBridges));
+    server.get("/bridge-search", lambdaToFastify(searchBridges));
+    server.get("/netflows/compare", lambdaToFastify(getNetflowsCompare));
     server.get("/healthcheck", async (_, reply) => {
       const { health, statusCode } = getHealthStatus();
       return reply.code(statusCode).send(health);


### PR DESCRIPTION
Three new read-only endpoints to improve observability and discoverability of bridge data.

**GET /stale-bridges**
Exposes the stale bridge detection logic (previously only sent to Discord) as an API response. Returns bridges and chains that have had no activity for 3 or more days, grouped by bridge name with the number of stale days per chain.

**GET /bridge-search?q=&chain=**
Search and filter bridges by name or chain. At least one of q (name substring) or chain is required. Eliminates the need for clients to fetch all bridges and filter client-side.

**GET /netflows/compare?period=day|week|month&chains=ethereum,arbitrum**
Compare netflows for specific chains side by side. Reuses the existing getNetflows query and filters to the requested chains, returning deposited, withdrawn, and net flow per chain. Supports up to 10 chains per request.