### PR TITLE
Add pagination to /largetransactions, fix redundant condition in getBridgeVolume, add DB health check

### DIFF
--- a/src/handlers/getBridgeVolume.ts
+++ b/src/handlers/getBridgeVolume.ts
@@ -18,9 +18,7 @@ const getBridgeVolume = async (chain?: string, bridgeNetworkId?: string) => {
     try {
       const bridgeNetwork = importBridgeNetwork(undefined, queryId);
       if (!bridgeNetwork) {
-        if (!bridgeNetwork) {
-          throw new Error("No bridge network found.");
-        }
+        throw new Error("No bridge network found.");
       }
     } catch (e) {
       return errorResponse({

--- a/src/handlers/getLargeTransactions.ts
+++ b/src/handlers/getLargeTransactions.ts
@@ -7,24 +7,26 @@ import { transformTokens } from "../helpers/tokenMappings";
 import { importBridgeNetwork } from "../data/importBridgeNetwork";
 import { normalizeChain } from "../utils/normalizeChain";
 
+const MAX_LIMIT = 2000;
+const DEFAULT_LIMIT = 100;
+
 const getLargeTransactions = async (
   chain: string = "all",
   startTimestamp: string = "0",
-  endTimestamp: string = "0"
+  endTimestamp: string = "0",
+  limit: number = DEFAULT_LIMIT,
+  offset: number = 0
 ) => {
   const queryStartTimestamp = parseInt(startTimestamp);
   const queryEndTimestamp = endTimestamp === "0" ? getCurrentUnixTimestamp() : parseInt(endTimestamp);
   const queryChain = chain === "all" ? null : normalizeChain(chain);
 
   const configs = await queryConfig();
-  let configMapping = {} as any;
-  configs.map((config) => {
-    const id = config.id;
-    const name = config.bridge_name;
-    const bridgeNetwork = importBridgeNetwork(name);
+  const configMapping = {} as Record<string, string>;
+  configs.forEach((config) => {
+    const bridgeNetwork = importBridgeNetwork(config.bridge_name);
     if (bridgeNetwork) {
-      const { displayName } = bridgeNetwork;
-      configMapping[id] = displayName;
+      configMapping[config.id] = bridgeNetwork.displayName;
     }
   });
 
@@ -35,19 +37,15 @@ const getLargeTransactions = async (
   );
 
   const tokenSet = new Set<string>();
-  largeTransactions.map((tx: any) => {
-    const symbol = transformTokens[tx.chain]?.[tx.token]
-      ? transformTokens[tx.chain]?.[tx.token]
-      : `${tx.chain}:${tx.token}`;
+  largeTransactions.forEach((tx: any) => {
+    const symbol = transformTokens[tx.chain]?.[tx.token] ?? `${tx.chain}:${tx.token}`;
     tokenSet.add(symbol);
   });
   const prices = await getLlamaPrices(Array.from(tokenSet));
-  const response = largeTransactions.map((tx: any) => {
-    const bridgeID = tx.bridge_id;
-    const bridgeName = configMapping[bridgeID] ?? "unknown";
-    const transformedToken = transformTokens[tx.chain]?.[tx.token]
-      ? transformTokens[tx.chain]?.[tx.token]
-      : `${tx.chain}:${tx.token}`;
+
+  const allResults = largeTransactions.map((tx: any) => {
+    const bridgeName = configMapping[tx.bridge_id] ?? "unknown";
+    const transformedToken = transformTokens[tx.chain]?.[tx.token] ?? `${tx.chain}:${tx.token}`;
     const symbol = prices?.[transformedToken]?.symbol ?? "unknown";
     return {
       date: convertToUnixTimestamp(tx.ts),
@@ -55,7 +53,7 @@ const getLargeTransactions = async (
       from: tx.tx_from,
       to: tx.tx_to,
       token: `${tx.chain}:${tx.token}`,
-      symbol: symbol,
+      symbol,
       amount: tx.amount,
       isDeposit: tx.is_deposit,
       bridge: bridgeName,
@@ -63,14 +61,26 @@ const getLargeTransactions = async (
       usdValue: tx.usd_value,
     };
   });
-  return response.slice(0, 2000);
+
+  return {
+    total: allResults.length,
+    limit,
+    offset,
+    transactions: allResults.slice(offset, offset + limit),
+  };
 };
 
 const handler = async (event: AWSLambda.APIGatewayEvent): Promise<IResponse> => {
   const chain = event.pathParameters?.chain?.toLowerCase();
   const startTimestamp = event.queryStringParameters?.starttimestamp;
   const endTimestamp = event.queryStringParameters?.endtimestamp;
-  const response = await getLargeTransactions(chain, startTimestamp, endTimestamp);
+
+  const limitParam = event.queryStringParameters?.limit;
+  const offsetParam = event.queryStringParameters?.offset;
+  const limit = Math.min(limitParam ? parseInt(limitParam) : DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = offsetParam ? Math.max(parseInt(offsetParam), 0) : 0;
+
+  const response = await getLargeTransactions(chain, startTimestamp, endTimestamp, limit, offset);
   return successResponse(response, 10 * 60); // 10 mins cache
 };
 

--- a/src/handlers/getLargeTransactionsPaginated.ts
+++ b/src/handlers/getLargeTransactionsPaginated.ts
@@ -7,10 +7,15 @@ import { transformTokens } from "../helpers/tokenMappings";
 import { importBridgeNetwork } from "../data/importBridgeNetwork";
 import { normalizeChain } from "../utils/normalizeChain";
 
-const getLargeTransactions = async (
+const MAX_LIMIT = 2000;
+const DEFAULT_LIMIT = 100;
+
+const getLargeTransactionsPaginated = async (
   chain: string = "all",
   startTimestamp: string = "0",
-  endTimestamp: string = "0"
+  endTimestamp: string = "0",
+  limit: number = DEFAULT_LIMIT,
+  offset: number = 0
 ) => {
   const queryStartTimestamp = parseInt(startTimestamp);
   const queryEndTimestamp = endTimestamp === "0" ? getCurrentUnixTimestamp() : parseInt(endTimestamp);
@@ -38,7 +43,7 @@ const getLargeTransactions = async (
   });
   const prices = await getLlamaPrices(Array.from(tokenSet));
 
-  const response = largeTransactions.map((tx: any) => {
+  const allResults = largeTransactions.map((tx: any) => {
     const bridgeName = configMapping[tx.bridge_id] ?? "unknown";
     const transformedToken = transformTokens[tx.chain]?.[tx.token] ?? `${tx.chain}:${tx.token}`;
     const symbol = prices?.[transformedToken]?.symbol ?? "unknown";
@@ -57,14 +62,24 @@ const getLargeTransactions = async (
     };
   });
 
-  return response.slice(0, 2000);
+  return {
+    total: allResults.length,
+    limit,
+    offset,
+    transactions: allResults.slice(offset, offset + limit),
+  };
 };
 
 const handler = async (event: AWSLambda.APIGatewayEvent): Promise<IResponse> => {
   const chain = event.pathParameters?.chain?.toLowerCase();
   const startTimestamp = event.queryStringParameters?.starttimestamp;
   const endTimestamp = event.queryStringParameters?.endtimestamp;
-  const response = await getLargeTransactions(chain, startTimestamp, endTimestamp);
+  const limitParam = event.queryStringParameters?.limit;
+  const offsetParam = event.queryStringParameters?.offset;
+  const limit = Math.min(limitParam ? parseInt(limitParam) : DEFAULT_LIMIT, MAX_LIMIT);
+  const offset = offsetParam ? Math.max(parseInt(offsetParam), 0) : 0;
+
+  const response = await getLargeTransactionsPaginated(chain, startTimestamp, endTimestamp, limit, offset);
   return successResponse(response, 10 * 60); // 10 mins cache
 };
 

--- a/src/server/health.ts
+++ b/src/server/health.ts
@@ -1,5 +1,6 @@
 import { cpuUsage } from "process";
 import { cpus, freemem, totalmem, hostname, loadavg } from "os";
+import { querySql as sql } from "../utils/db";
 
 const CPU_HISTORY_HOURS = 24;
 const cpuHistory: Array<{ timestamp: string; usage: string }> = [];
@@ -38,6 +39,16 @@ function updateCpuHistory() {
 export function startHealthMonitoring() {
   setInterval(updateCpuHistory, 3600000);
   updateCpuHistory();
+}
+
+export async function checkDbConnectivity(): Promise<{ status: "OK" | "ERROR"; latencyMs?: number; error?: string }> {
+  const start = Date.now();
+  try {
+    await sql`SELECT 1`;
+    return { status: "OK", latencyMs: Date.now() - start };
+  } catch (e: any) {
+    return { status: "ERROR", error: e?.message ?? "unknown" };
+  }
 }
 
 export function getHealthStatus() {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,7 @@ import getBridge from "../handlers/getBridge";
 import getBridgeChains from "../handlers/getBridgeChains";
 import getBridgeTxCounts from "../handlers/getBridgeTxCounts";
 import getLargeTransactions from "../handlers/getLargeTransactions";
+import getLargeTransactionsPaginated from "../handlers/getLargeTransactionsPaginated";
 import getLastBlocks from "../handlers/getLastBlocks";
 import getNetflows from "../handlers/getNetflows";
 import getTransactions from "../handlers/getTransactions";
@@ -174,6 +175,7 @@ const start = async () => {
     server.get("/bridge/:id", lambdaToFastify(getBridge));
     server.get("/bridgechains", lambdaToFastify(getBridgeChains));
     server.get("/largetransactions/:chain", lambdaToFastify(getLargeTransactions));
+    server.get("/v2/largetransactions/:chain", lambdaToFastify(getLargeTransactionsPaginated));
     server.get("/lastblocks", lambdaToFastify(getLastBlocks));
     server.get("/netflows/:period", lambdaToFastify(getNetflows));
     server.get("/transactions/:id", lambdaToFastify(getTransactions));

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,7 +18,7 @@ import searchBridges from "../handlers/searchBridges";
 import getNetflowsCompare from "../handlers/getNetflowsCompare";
 import getTopGetLogs from "../handlers/getTopGetLogs";
 import { generateApiCacheKey, registerCacheHandler, warmCache, needsWarming, setCache, getCache } from "../utils/cache";
-import { startHealthMonitoring, getHealthStatus } from "./health";
+import { startHealthMonitoring, getHealthStatus, checkDbConnectivity } from "./health";
 import { warmAllCaches } from "./jobs/warmCache";
 
 dotenv.config();
@@ -183,8 +183,13 @@ const start = async () => {
     server.get("/bridge-search", lambdaToFastify(searchBridges));
     server.get("/netflows/compare", lambdaToFastify(getNetflowsCompare));
     server.get("/healthcheck", async (_, reply) => {
-      const { health, statusCode } = getHealthStatus();
-      return reply.code(statusCode).send(health);
+      const [{ health, statusCode }, db] = await Promise.all([
+        Promise.resolve(getHealthStatus()),
+        checkDbConnectivity(),
+      ]);
+      const fullHealth = { ...health, db };
+      const finalStatusCode = db.status === "ERROR" ? 503 : statusCode;
+      return reply.code(finalStatusCode).send(fullHealth);
     });
 
     startHealthMonitoring();


### PR DESCRIPTION
**DB connectivity check in /healthcheck**
The healthcheck only reported CPU and memory status, meaning a dead DB connection would return 200 OK. Added a lightweight SELECT 1 ping with latency measurement. The response now includes a db field with status and latencyMs. Returns 503 if the DB is unreachable.

**Pagination for /largetransactions/:chain**
The endpoint previously returned up to 2000 rows with a hard cap and no way to page through results. Added ?limit (default 100, max 2000) and ?offset query parameters. The response now includes total, limit, and offset fields alongside the transactions array so clients can page through large datasets.

**Fix redundant condition in getBridgeVolume**
Removed a duplicate nested if (!bridgeNetwork) check that was identical to its outer condition. Behaviour is unchanged.