### PR TITLE
fixed three bugs across getTransactions, insertConfigRow, and aggregateData

### DIFF
--- a/src/handlers/getTransactions.ts
+++ b/src/handlers/getTransactions.ts
@@ -62,7 +62,7 @@ const getTransactions = async (
       if (addressHash) {
         if (
           !(
-            (addressHash === tx.tx_to.toLowerCase() || addressHash === tx.tx_from.toLowerCase()) &&
+            (addressHash === tx.tx_to?.toLowerCase() || addressHash === tx.tx_from?.toLowerCase()) &&
             addressChain === tx.chain
           )
         )

--- a/src/utils/aggregate.ts
+++ b/src/utils/aggregate.ts
@@ -598,7 +598,7 @@ export const aggregateData = async (
       console.error(errString, e);
     }
   }
-  largeTxs.map(async (largeTx) => {
+  await Promise.all(largeTxs.map(async (largeTx) => {
     const txPK = largeTx.id;
     const timestamp = largeTx.ts;
     const usdValue = largeTx.usdValue;
@@ -620,5 +620,5 @@ export const aggregateData = async (
       });
       console.log(errString, e);
     }
-  });
+  }));
 };

--- a/src/utils/wrappa/postgres/write.ts
+++ b/src/utils/wrappa/postgres/write.ts
@@ -128,10 +128,11 @@ export const insertConfigRow = async (
   }
   for (let i = 0; i < 5; i++) {
     try {
-      return sql`
-        INSERT INTO bridges.config ${sql(paramsToAvoidTsError)} 
+      await sql`
+        INSERT INTO bridges.config ${sql(paramsToAvoidTsError)}
         ON CONFLICT (bridge_name, chain) DO NOTHING;
       `;
+      return;
     } catch (e) {
       if (i >= 4) {
         throw new Error(`Could not insert config row for ${params.bridge_name} on ${params.chain}`);


### PR DESCRIPTION
getTransactions: added null gaurd to prevent typerror crash
insertConfigRow: an await was missing on the sql insert, so retry loop was dead code and errors were never caught so I added await and separated the return so retries work correctly
aggregateData: largeTxs.map with async callback was fire and forget, large tx rows could be lost if the function returned before inserts completed -> wrapped with promise all to properly await all inserts, went for promise all rather than promise pool as I thouhgt these are simple DB inserts with a retry loop, and the count will be small