### PR TITLE
Update Pheasant Network contract addresses

### DIFF
--- a/src/adapters/pheasant-network/index.ts
+++ b/src/adapters/pheasant-network/index.ts
@@ -2,6 +2,7 @@ import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeA
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 
 export const bridgesAddress = {
+  ethereum: "0x20A41749545eB0C6266838257aDeA7b86d5369Ac",
   optimism: "0x0C4F10259c8b5Ed7238B76A0a6EfEf82cd2908Bf",
   arbitrum: "0x97450C9B5fC6D1b86bF87EFDCbB137f26F8b497e",
   scroll: "0xcAebc3309bFe45313922BFBa1a36C4458937E2A2",

--- a/src/adapters/pheasant-network/index.ts
+++ b/src/adapters/pheasant-network/index.ts
@@ -2,16 +2,16 @@ import { BridgeAdapter, PartialContractEventParams } from "../../helpers/bridgeA
 import { getTxDataFromEVMEventLogs } from "../../helpers/processTransactions";
 
 export const bridgesAddress = {
-  optimism: "0x6Aca7B9a3700B19CB5909208704A4e71B30e7840",
-  arbitrum: "0x3B5357D73fC65487449Cd68550adB9F46A0b8068",
-  scroll: "0x4e44f012B66C839A9904d128B93F80Dd5e3a1b21",
-  base: "0xDce25728E076ee5BCD146fD9F5FB5360ad18bCa0",
-  linea: "0x505cf4BB10bD1320f2F07d445bBe06A721B6CF53",
-  taiko: "0x04e28F7244980d3280F3b485D9cDA4b58F6C99B5",
-  morph: "0xbD45fC4826Fd0981F1A3d8330cf75309fBC9ce33",
-  era: "0x85308f2393A8F49E64e3b71Bb24f57614844497c",
-  unichain: "0xbD192e039F3D1A9BC84A12679fdE2F40ae7b4FfF",
-  megaeth: "0x9E7FCb2c0b8a5461BCc7078a2E37886f254B060b",
+  optimism: "0x0C4F10259c8b5Ed7238B76A0a6EfEf82cd2908Bf",
+  arbitrum: "0x97450C9B5fC6D1b86bF87EFDCbB137f26F8b497e",
+  scroll: "0xcAebc3309bFe45313922BFBa1a36C4458937E2A2",
+  base: "0x8A7Ee008B18DF025bc778B034Dbd7ad507221e10",
+  linea: "0xbe7F97E4B54747B75B8aaF84ecafE876BaCA9198",
+  taiko: "0x7a651Ef5A53B128d406c9093feA2650e8A6156b5",
+  morph: "0x56DE23ed536b2Bf8D398F2E1703Ce9aDb48B09F4",
+  era: "0xaFDaD3F10c7c906434422F229bCfB120bcE51C6c",
+  unichain: "0x81505846153403EBd6Cf5e89dD9f3eF2277fe374",
+  megaeth: "0x554590DC69830507248Ebc7AD3Bc9d6fA94488d2",
 } as const;
 
 type SupportedBridgeChains = keyof typeof bridgesAddress;


### PR DESCRIPTION
## Summary
- update the Pheasant Network bridge contract addresses
- add the Ethereum mainnet bridge address