### PR TITLE
Add Robinhood Chain for Relay

### DIFF
--- a/src/adapters/relay/index.ts
+++ b/src/adapters/relay/index.ts
@@ -323,6 +323,7 @@ export const slugToChainId: Record<string, number> = {
   "proof-of-play-boss": 70701,
   katana: 747474,
   monad: 143,
+  robinhood: 4663,
 };
 
 export const chainIdToSlug: Record<number, string> = Object.fromEntries(

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -2621,6 +2621,7 @@ export default [
       "Proof of Play Boss",
       "Rari",
       "Redstone",
+      "Robinhood",
       "Scroll",
       "Sei",
       "Shape",


### PR DESCRIPTION
Adds Robinhood Chain (chain id 4663) to the relay adapter, same as #451 did for Monad. Relay already supports the chain but its transactions were being skipped since the id wasn't in `slugToChainId`.

`npm run test relay` doesn't cover this adapter since it runs through the dedicated handler, so I tested the conversion directly against recent requests on chain 4663:

```
Fetched 50 recent Relay requests touching chainId 4663
Robinhood transactions converted: 19 deposits ($2657), 16 withdrawals ($5688)
```

`npm run ts` passes.
