### PR TITLE
1sec: price ICP-native assets instead of dropping them

### DIFF
--- a/src/helpers/tokenMappings.ts
+++ b/src/helpers/tokenMappings.ts
@@ -16,7 +16,7 @@ export const transformTokens = {
     "0x77776b40c3d75cb07ce54dea4b2fd1d07f865222": "bsc:0xe9e7cea3dedca5984780bafc599bd69add087d56",
     "0x00f3c42833c3170159af4e92dbb451fb3f708917": "coingecko:internet-computer",
     "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": "coingecko:bob-3",
-    "0xdb95092c454235e7e666c4e226dbbbbcdeb499d25": "coingecko:openchat",
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": "coingecko:openchat",
     "0x86856814e74456893cfc8946bedcbb472b5fa856": "coingecko:gold-dao",
   },
   bsc: {
@@ -52,7 +52,7 @@ export const transformTokens = {
     "0x600e576f9d853c95d58029093a16ee49646f3ca5": "arbitrum:0x93b346b6bc2548da6a1e7d98e9a421b42541425b",
     "0x00f3c42833c3170159af4e92dbb451fb3f708917": "coingecko:internet-computer",
     "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": "coingecko:bob-3",
-    "0xdb95092c454235e7e666c4e226dbbbbcdeb499d25": "coingecko:openchat",
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": "coingecko:openchat",
     "0x86856814e74456893cfc8946bedcbb472b5fa856": "coingecko:gold-dao",
   },
   optimism: {
@@ -84,7 +84,7 @@ export const transformTokens = {
   base: {
     "0x00f3c42833c3170159af4e92dbb451fb3f708917": "coingecko:internet-computer",
     "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": "coingecko:bob-3",
-    "0xdb95092c454235e7e666c4e226dbbbbcdeb499d25": "coingecko:openchat",
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": "coingecko:openchat",
     "0x86856814e74456893cfc8946bedcbb472b5fa856": "coingecko:gold-dao",
   },
   tron: {
@@ -117,6 +117,11 @@ export const transformTokenDecimals = {
     "0xd8772edbf88bba2667ed011542343b0eddacda47": 18,
     "0x430ebff5e3e80a6c58e7e6ada1d90f5c28aa116d": 6,
     "0xf5e11df1ebcf78b6b6d26e04ff19cd786a1e81dc": 18,
+    // ICP-native assets: priced by coingecko id, which carries no decimals
+    "0x00f3c42833c3170159af4e92dbb451fb3f708917": 8,
+    "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": 8,
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": 8,
+    "0x86856814e74456893cfc8946bedcbb472b5fa856": 8,
   },
   bsc: {
     "0x98a5737749490856b401db5dc27f522fc314a4e1": 6,
@@ -147,6 +152,18 @@ export const transformTokenDecimals = {
     "0xaa4bf442f024820b2c28cd0fd72b82c63e66f56c": 6,
     "0xf39b7be294cb36de8c510e267b82bb588705d977": 6,
     "0x600e576f9d853c95d58029093a16ee49646f3ca5": 6,
+    // ICP-native assets: priced by coingecko id, which carries no decimals
+    "0x00f3c42833c3170159af4e92dbb451fb3f708917": 8,
+    "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": 8,
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": 8,
+    "0x86856814e74456893cfc8946bedcbb472b5fa856": 8,
+  },
+  base: {
+    // ICP-native assets: priced by coingecko id, which carries no decimals
+    "0x00f3c42833c3170159af4e92dbb451fb3f708917": 8,
+    "0xecc5f868add75f4ff9fd00bbbde12c35ba2c9c89": 8,
+    "0xdb95092c454235e7e666c4e226dbbbcdeb499d25": 8,
+    "0x86856814e74456893cfc8946bedcbb472b5fa856": 8,
   },
   optimism: {
     "0xdecc0c09c3b5f6e92ef4184125d5648a66e35298": 6,


### PR DESCRIPTION
1sec's four ICP-native assets (ICP, BOB, CHAT, GLDT) are contributing **$0** to bridge volume on ethereum, arbitrum and base.

### Why

`aggregate.ts` skips a token outright when it has neither a decimals override nor a decimals value from the price API:

```ts
const transformedDecimals = transformTokenDecimals[priceChain]?.[tokenL] ?? null;
tokenKey = transformTokens[priceChain]?.[tokenL] ?? `${priceChain}:${tokenL}`;
...
if (transformedDecimals === null && decimals === undefined) {
  console.log(`Skipping token ${tokenKey} - no decimals available`);
}
```

These four are mapped to `coingecko:` ids, and a coingecko key returns a price but **no `decimals` field**:

```
coingecko:internet-computer                        price=$2.1536   decimals=undefined
coingecko:bob-3                                    price=$0.0735   decimals=undefined
coingecko:openchat                                 price=$0.0486   decimals=undefined
coingecko:gold-dao                                 price=$0.0035   decimals=undefined
ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 price=$0.9998  decimals=6
```

None of the four had an entry in `transformTokenDecimals`, and there was no `base` block there at all — so every transfer of them was dropped.

### Separately, the openchat key was malformed

```
1sec adapter (src/adapters/1sec/index.ts):  0xDb95092C454235E7e666c4E226dBBbCdeb499d25   (42 chars)
tokenMappings key:                          0xdb95092c454235e7e666c4e226dbbbbcdeb499d25  (43 chars)
```

One extra `b`. It could never match the real address, so CHAT fell through to `<chain>:0xdb95...`, which returns no price on ethereum, arbitrum or base — also $0.

### Decimals verified on-chain

`decimals()` called directly on each contract:

| token | ethereum | arbitrum | base | symbol |
|---|---|---|---|---|
| ICP | 8 | 8 | 8 | ICP |
| BOB | 8 | 8 | 8 | BOB |
| CHAT | 8 | 8 | 8 | CHAT |
| GLDT | 8 | 8 | 8 | GLDT |

### Effect

Resolving `transformTokens` / `transformTokenDecimals` for all 12 token-chain combinations:

```
before:  12 / 12  ->  $0   (9 skipped for missing decimals, 3 unmatched by the typo)
after:   12 / 12  ->  counted, /1e8
```

Currently outstanding supply of these assets, all presently valued at $0 by the aggregator:

| token | chain | supply | USD |
|---|---|---|---|
| ICP | ethereum | 487,602.58 | $1,049,888 |
| ICP | base | 247,263.78 | $532,400 |
| BOB | base | 64,263.15 | $4,725 |
| others | | | ~$130 |
| **total** | | | **$1,587,146** |

`tsc --noEmit` exits 0.
