### PR TITLE
Track Mayan transactions through the explorer API

### DIFF
--- a/src/adapters/mayan/index.ts
+++ b/src/adapters/mayan/index.ts
@@ -147,6 +147,14 @@ export const sourceChainNames = CHAINS.map((chain) => chain.name);
 /** Services worth querying when a chain has to be split. */
 export const servicesForChain = (name: string): string[] => CHAINS.find((chain) => chain.name === name)?.services ?? [];
 
+/** Services to split a truncated chain by: the static table plus whatever the unsplit walk saw. */
+export const servicesToSplit = (fromChain: string, observed: Iterable<string> = []): string[] => {
+  const services = new Set(servicesForChain(fromChain));
+  for (const service of observed) services.add(service);
+  services.delete("MONO_CHAIN"); // same-chain swaps; normalization skips them all
+  return [...services];
+};
+
 const chainSlugByWormholeId: Record<string, string> = Object.fromEntries(
   CHAINS.map((chain) => [chain.wormholeId, chain.slug])
 );
@@ -395,7 +403,9 @@ export type IngestWindow = {
  */
 export const resolveIngestWindow = (checkpointMs: number | null, nowMs: number): IngestWindow => {
   const earliestReachable = nowMs - MAX_LOOKBACK_MS;
-  const requested = checkpointMs ? checkpointMs - CHECKPOINT_OVERLAP_MS : earliestReachable;
+  // A future checkpoint would collect nothing, and the monotonic save could never lower it.
+  const effectiveMs = checkpointMs === null ? null : Math.min(checkpointMs, nowMs);
+  const requested = effectiveMs ? effectiveMs - CHECKPOINT_OVERLAP_MS : earliestReachable;
   return { fromMs: Math.max(requested, earliestReachable), unreachableGap: requested < earliestReachable };
 };
 

--- a/src/adapters/mayan/index.ts
+++ b/src/adapters/mayan/index.ts
@@ -1,170 +1,621 @@
-import dayjs from "dayjs";
-type WormholeBridgeEvent = {
-  block_timestamp: string;
-  transaction_hash: string;
-  token_transfer_from_address: string;
-  token_transfer_to_address: string;
-  token_address: string;
-  token_usd_amount: string;
-  token_amount: string;
-  source_chain: string;
-  destination_chain: string;
-  is_deposit?: boolean;
+import fetch from "node-fetch";
+import { BridgeAdapter } from "../../helpers/bridgeAdapter.type";
+import { EventData } from "../../utils/types";
+import { isAbortError, NonRetryableError, throwIfAborted, waitWithSignal } from "../../utils/errors";
+
+/**
+ * Reads Mayan's public explorer API, which needs no credentials, and turns each swap into the rows
+ * it produces. `runMayan` owns fetching and persistence.
+ *
+ * `format=raw` is required: the default shape reports a source amount and a source price belonging
+ * to different tokens. It omits the derived completion flag, hence `isSettled`.
+ */
+const DEFAULT_EXPLORER_URL = "https://explorer-api.mayan.finance/v3/swaps";
+
+/** Server-side query limits; larger values are rejected. MAX_OFFSET caps how far one query reaches. */
+const PAGE_SIZE = 100;
+const MAX_OFFSET = 3000;
+
+const NULL_ADDRESS = "0x0000000000000000000000000000000000000000";
+/** Placeholder for a counterparty the feed does not expose. Aggregation drops zero-address rows. */
+const UNKNOWN_ADDRESS = "0x";
+
+/** Divergence between the two sides of a swap above which neither price is treated as corroborated. */
+const MAX_PRICE_DIVERGENCE = 10;
+
+/**
+ * Most a swap may be worth when only the source side could be priced, since nothing is left to check
+ * that price against. Destination-only pricing is trusted: it is the side the feed reports reliably.
+ */
+const MAX_SOURCE_ONLY_USD = 1_000_000;
+
+const HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * The feed is ordered by initiation but swaps settle later, so a resume starts behind the checkpoint
+ * to pick up ones that were still pending when last read.
+ */
+const CHECKPOINT_OVERLAP_MS = 2 * HOUR_MS;
+/** How far back a run will reach, sized so no partition approaches the offset cap. */
+const MAX_LOOKBACK_MS = 12 * HOUR_MS;
+/** Window the bridge reports volume over. */
+export const VOLUME_WINDOW_MS = 24 * HOUR_MS;
+
+/** Queries can take many seconds to answer, so allow generous timeouts. */
+const REQUEST_RETRIES = 8;
+const REQUEST_TIMEOUT_MS = 60_000;
+const RETRY_BASE_MS = 5_000;
+const RETRY_MAX_MS = 60_000;
+
+type MayanChain = {
+  /** Value accepted by the `fromChain` query parameter. */
+  name: string;
+  /** Wormhole chain id, which is how the feed reports source and destination. */
+  wormholeId: string;
+  /** Chain key used by bridges-server and DefiLlama. */
+  slug: string;
+  /**
+   * Cross-chain services this chain runs, and the only ones queried when it has to be split. Asking
+   * for a combination that has no swaps is far slower than asking for one that does.
+   */
+  services: string[];
 };
 
-const chains = [
-  "solana",
-  "ethereum",
-  "base",
-  "arbitrum",
-  "optimism",
-  "polygon",
-  "avalanche",
-  "bsc",
-  "sui",
-  "unichain",
-  "aptos",
-  "linea",
-  "monad",
+/**
+ * Every chain Mayan settles on. HyperEVM and HyperCore both report as DefiLlama's "Hyperliquid";
+ * Aptos is retired but kept so its existing `bridges.config` row keeps resolving.
+ */
+const CHAINS: MayanChain[] = [
+  {
+    name: "solana",
+    wormholeId: "1",
+    slug: "solana",
+    services: [
+      "SWIFT_V2",
+      "MCTP_FAST_SWAP",
+      "MCTP_FAST_BRIDGE",
+      "MCTP_SWAP",
+      "MCTP_BRIDGE",
+      "WH_BRIDGE",
+      "MCTP_BRIDGE_WITH_UNLOCK",
+    ],
+  },
+  {
+    name: "ethereum",
+    wormholeId: "2",
+    slug: "ethereum",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_FAST_BRIDGE", "MCTP_BRIDGE", "MCTP_SWAP", "WH_BRIDGE"],
+  },
+  { name: "bsc", wormholeId: "4", slug: "bsc", services: ["SWIFT_V2"] },
+  {
+    name: "polygon",
+    wormholeId: "5",
+    slug: "polygon",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_BRIDGE", "MCTP_FAST_BRIDGE", "MCTP_SWAP", "MCTP_BRIDGE_WITH_UNLOCK"],
+  },
+  {
+    name: "avalanche",
+    wormholeId: "6",
+    slug: "avalanche",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_BRIDGE", "MCTP_FAST_BRIDGE", "MCTP_BRIDGE_WITH_UNLOCK", "MCTP_SWAP"],
+  },
+  { name: "sui", wormholeId: "21", slug: "sui", services: ["MCTP_SWAP", "MCTP_BRIDGE", "MCTP_BRIDGE_WITH_UNLOCK"] },
+  { name: "aptos", wormholeId: "22", slug: "aptos", services: [] },
+  {
+    name: "arbitrum",
+    wormholeId: "23",
+    slug: "arbitrum",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_FAST_BRIDGE", "MCTP_BRIDGE", "MCTP_SWAP", "MCTP_BRIDGE_WITH_UNLOCK"],
+  },
+  {
+    name: "optimism",
+    wormholeId: "24",
+    slug: "optimism",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_BRIDGE", "MCTP_FAST_BRIDGE", "MCTP_SWAP", "MCTP_BRIDGE_WITH_UNLOCK"],
+  },
+  {
+    name: "base",
+    wormholeId: "30",
+    slug: "base",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_BRIDGE", "MCTP_FAST_BRIDGE", "MCTP_SWAP", "MCTP_BRIDGE_WITH_UNLOCK"],
+  },
+  { name: "linea", wormholeId: "38", slug: "linea", services: ["MCTP_FAST_SWAP", "MCTP_FAST_BRIDGE"] },
+  {
+    name: "unichain",
+    wormholeId: "44",
+    slug: "unichain",
+    services: ["MCTP_FAST_SWAP", "MCTP_BRIDGE", "MCTP_FAST_BRIDGE"],
+  },
+  {
+    name: "hyperevm",
+    wormholeId: "47",
+    slug: "hyperliquid",
+    services: ["SWIFT_V2", "MCTP_FAST_SWAP", "MCTP_FAST_BRIDGE"],
+  },
+  {
+    name: "monad",
+    wormholeId: "48",
+    slug: "monad",
+    services: ["SWIFT_V2", "MCTP_FAST_BRIDGE", "MCTP_FAST_SWAP"],
+  },
+  { name: "hypercore", wormholeId: "65000", slug: "hyperliquid", services: ["HC_WITHDRAW"] },
 ];
 
-export const chainNameMapping: { [key: string]: string } = {
-  ethereum: "Ethereum",
-  avalanche: "Avalanche",
-  avax: "Avalanche",
-  polygon: "Polygon",
-  arbitrum: "Arbitrum",
-  optimism: "Optimism",
-  fantom: "Fantom",
-  base: "Base",
-  solana: "Solana",
-  sui: "Sui",
-  aptos: "Aptos",
-  celo: "Celo",
-  mantle: "Mantle",
-  scroll: "Scroll",
-  algorand: "Algorand",
-  sei: "Sei",
-  moonbeam: "Moonbeam",
-  injective: "Injective",
-  kaia: "Kaia",
-  oasis: "Oasis",
-  BNB_Smart_Chain: "BSC",
-  bnb_smart_chain: "BSC",
-  terra: "Terra Classic",
-  terra2: "Terra",
-  "terra classic": "Terra Classic",
-  near: "Near",
-  karura: "Karura",
-  acala: "Acala",
-  wormchain: "Wormchain",
-  xlayer: "xLayer",
-  blast: "Blast",
-  xpla: "XPLA",
+/** Source chains to walk. A swap has exactly one source chain, so this covers the feed once. */
+export const sourceChainNames = CHAINS.map((chain) => chain.name);
+
+/** Services worth querying when a chain has to be split. */
+export const servicesForChain = (name: string): string[] => CHAINS.find((chain) => chain.name === name)?.services ?? [];
+
+const chainSlugByWormholeId: Record<string, string> = Object.fromEntries(
+  CHAINS.map((chain) => [chain.wormholeId, chain.slug])
+);
+
+/** Subset of the explorer's raw swap row this adapter consumes. */
+export type MayanSwap = {
+  orderId?: string | null;
+  service?: string | null;
+  status?: string | null;
+  customPayloadSettleTxHash?: string | null;
+  meta?: { hypercoreData?: { redeemTxHash?: string | null } | null } | null;
+  initiatedAt?: string | null;
+  trader?: string | null;
+  destAddress?: string | null;
+  sourceTxHash?: string | null;
+  fulfillTxHash?: string | null;
+  sourceChain?: string | null;
+  destChain?: string | null;
+  fromAmount?: string | number | null;
+  toAmount?: string | number | null;
+  fromTokenAddress?: string | null;
+  toTokenAddress?: string | null;
+  fromTokenPrice?: number | null;
+  toTokenPrice?: number | null;
 };
 
-export function normalizeChainName(chainName: string): string {
-  const lowercaseChain = chainName.toLowerCase();
+/** One side of a swap, ready to be written to `bridges.transactions`. */
+export type SwapLeg = {
+  chain: string;
+  originChain: string | null;
+  txHash: string;
+  timestamp: number;
+  from: string;
+  to: string;
+  token: string;
+  /** USD with cents. The column is a VARCHAR read with BigNumber, so decimals survive. */
+  amountUsd: string;
+  isDeposit: boolean;
+};
 
-  const mapping = chainNameMapping[lowercaseChain] || chainNameMapping[chainName];
+/**
+ * Statuses the feed reports once value has reached the recipient. The raw response carries `status`
+ * rather than the completion flag the default response derives, so that judgement is made here.
+ */
+const SETTLED_STATUSES = new Set([
+  "ORDER_FROZEN",
+  "ORDER_SETTLED",
+  "ORDER_UNLOCKED",
+  "REDEEMED_ON_EVM",
+  "REDEEMED_ON_APTOS",
+  "SETTLED_ON_SOLANA",
+  "REDEEMED_ON_EVM_WITH_FEE",
+  "REDEEMED_ON_EVM_WITH_LOCKED_FEE",
+  "REDEEMED_ON_SOL_WITH_FEE",
+  "REDEEMED_ON_SOL_WITH_LOCKED_FEE",
+  "REDEEMED_ON_SUI_WITH_FEE",
+  "REDEEMED_ON_SUI_WITH_LOCKED_FEE",
+  "MCTP_FEE_UNLOCKED",
+  "SETTLED_ON_SOLANA_MCTP",
+  "SWAPPED_ON_EVM_MCTP",
+  "SWAPPED_ON_SUI_MCTP",
+  "SWAP_LAYER_ORDER_SETTLED",
+  "HC_SWIFT_ORDER_FULFILLED",
+  "HC_REDEEMED_ON_ARBITRUM",
+]);
 
-  if (mapping) {
-    return mapping?.toLowerCase();
+/** Settled for every service except the Wormhole bridge, where the redeem leg is still pending. */
+const REDEEM_PENDING_STATUSES = new Set(["REDEEM_SEQUENCE_RECEIVED", "REDEEM_VAA_SIGNED"]);
+const REDEEM_PENDING_SERVICES = new Set(["WH_BRIDGE", "WH_SWAP"]);
+
+const isSettled = (swap: MayanSwap): boolean => {
+  const status = swap.status ?? "";
+  const service = swap.service ?? "";
+
+  // A Swift order carrying a HyperCore deposit is not done until that deposit lands, even though
+  // the order itself reads as settled.
+  const hypercoreData = swap.meta?.hypercoreData;
+  if (
+    (service === "SWIFT_SWAP" || service === "SWIFT_V2") &&
+    hypercoreData &&
+    !(hypercoreData.redeemTxHash || swap.customPayloadSettleTxHash) &&
+    (status === "ORDER_SETTLED" || status === "ORDER_UNLOCKED")
+  ) {
+    return false;
   }
 
-  return chainName?.toLowerCase();
-}
-
-// Map wormhole chain IDs to chain names
-const wormholeChainMap: { [key: string]: string } = {
-  "1": "solana",
-  "2": "ethereum",
-  "30": "base",
-  "23": "arbitrum",
-  "24": "optimism",
-  "5": "polygon",
-  "6": "avalanche",
-  "4": "bsc",
-  "21": "sui",
-  "44": "unichain",
-  "22": "aptos",
-  "38": "linea",
+  if (REDEEM_PENDING_STATUSES.has(status)) return !REDEEM_PENDING_SERVICES.has(service);
+  return SETTLED_STATUSES.has(status);
 };
 
-export const fetchMayanEvents = async (fromTimestamp: number, toTimestamp: number): Promise<WormholeBridgeEvent[]> => {
-  let allResults: WormholeBridgeEvent[] = [];
-  let offset = 0;
-  const BATCH_SIZE = 10000;
-  const API_KEY = process.env.MAYAN_API_KEY || "";
+export type SwapSkipReason = "unsettled" | "same_chain" | "invalid_timestamp" | "unpriced" | "uncorroborated";
 
-  // Convert timestamps to milliseconds for API
-  const startMs = fromTimestamp * 1000;
-  const endMs = toTimestamp * 1000;
+export type NormalizedSwap = {
+  legs: SwapLeg[];
+  /** Set when the swap yields no volume at all. */
+  skipped?: SwapSkipReason;
+  /** Chain ids with no entry in `CHAINS`, whose legs could not be attributed. */
+  unmappedChainIds: string[];
+  pricedFromSource: boolean;
+  priceConflict: boolean;
+};
 
-  while (true) {
+const toNumber = (value: string | number | null | undefined): number | null => {
+  if (value === null || value === undefined) return null;
+  const parsed = typeof value === "string" ? Number(value) : value;
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/** Value of one side of a swap, or null when its amount or price is unusable. */
+const sideValueUsd = (amount: string | number | null | undefined, price: number | null | undefined): number | null => {
+  const parsedAmount = toNumber(amount);
+  const parsedPrice = toNumber(price);
+  if (parsedAmount === null || parsedAmount <= 0) return null;
+  if (parsedPrice === null || parsedPrice <= 0) return null;
+  const value = parsedAmount * parsedPrice;
+  return Number.isFinite(value) && value > 0 ? value : null;
+};
+
+/**
+ * Both sides of a swap are worth the same money, so one value is written to both legs. The
+ * destination side leads, being the more reliably priced. Neither side is authoritative on its own,
+ * so where the two diverge beyond `MAX_PRICE_DIVERGENCE` the lower bound is taken rather than an
+ * uncorroborated price.
+ */
+const resolveSwapValue = (
+  swap: MayanSwap
+): { valueUsd: number | null; pricedFromSource: boolean; priceConflict: boolean } => {
+  const destination = sideValueUsd(swap.toAmount, swap.toTokenPrice);
+  const source = sideValueUsd(swap.fromAmount, swap.fromTokenPrice);
+
+  if (destination === null || source === null) {
+    return {
+      valueUsd: destination ?? source,
+      pricedFromSource: destination === null && source !== null,
+      priceConflict: false,
+    };
+  }
+
+  const divergence = destination / source;
+  const priceConflict = divergence > MAX_PRICE_DIVERGENCE || divergence < 1 / MAX_PRICE_DIVERGENCE;
+  return {
+    valueUsd: priceConflict ? Math.min(destination, source) : destination,
+    pricedFromSource: false,
+    priceConflict,
+  };
+};
+
+const addressOrPlaceholder = (address: string | null | undefined): string =>
+  address && address.toLowerCase() !== NULL_ADDRESS ? address : UNKNOWN_ADDRESS;
+
+/**
+ * Token totals are keyed by address without normalising case, so mixed casing splits a token in two.
+ * Only a canonical EVM address is safe to fold: Sui coin types are `0x`-prefixed but their module
+ * and struct names are case-sensitive (`0x2::sui::SUI`).
+ */
+const EVM_ADDRESS = /^0x[0-9a-fA-F]{40}$/;
+
+const normalizeToken = (address: string | null | undefined): string => {
+  if (!address) return NULL_ADDRESS;
+  return EVM_ADDRESS.test(address) ? address.toLowerCase() : address;
+};
+
+/**
+ * Resolves a Wormhole chain id, dropping and reporting the leg when it is unknown. Failing the run
+ * instead would turn any new chain into a total outage, since the table above is static.
+ */
+const resolveChainSlug = (chainId: string | null | undefined, unmapped: string[]): string | undefined => {
+  if (!chainId) return undefined;
+  const slug = chainSlugByWormholeId[chainId];
+  if (!slug) unmapped.push(chainId);
+  return slug;
+};
+
+export const normalizeSwap = (swap: MayanSwap): NormalizedSwap => {
+  const unmappedChainIds: string[] = [];
+  const sourceSlug = resolveChainSlug(swap.sourceChain, unmappedChainIds);
+  const destinationSlug = resolveChainSlug(swap.destChain, unmappedChainIds);
+
+  const empty: NormalizedSwap = { legs: [], unmappedChainIds, pricedFromSource: false, priceConflict: false };
+
+  // Refunded, expired and in-flight swaps moved no value end to end.
+  if (!isSettled(swap)) return { ...empty, skipped: "unsettled" };
+
+  // Same-chain swaps are a DEX product, not a bridge transfer, so they are out of scope for a
+  // cross-chain volume series. Compared by chain key rather than by id: HyperEVM and HyperCore carry
+  // different ids but are one chain here, so value moving between them never leaves it.
+  if (sourceSlug && destinationSlug && sourceSlug === destinationSlug) {
+    return { ...empty, skipped: "same_chain" };
+  }
+
+  const timestamp = Date.parse(swap.initiatedAt ?? "");
+  if (!Number.isFinite(timestamp) || timestamp <= 0) return { ...empty, skipped: "invalid_timestamp" };
+
+  const { valueUsd, pricedFromSource, priceConflict } = resolveSwapValue(swap);
+  // Below a cent the amount renders as "0.00", which aggregation discards outright; skipping here
+  // keeps the table free of rows that can never contribute.
+  if (valueUsd === null || valueUsd < 0.005) return { ...empty, skipped: "unpriced" };
+  if (pricedFromSource && valueUsd > MAX_SOURCE_ONLY_USD) {
+    return { ...empty, pricedFromSource, skipped: "uncorroborated" };
+  }
+
+  const amountUsd = valueUsd.toFixed(2);
+  const legs: SwapLeg[] = [];
+
+  if (sourceSlug && swap.sourceTxHash) {
+    legs.push({
+      chain: sourceSlug,
+      originChain: null,
+      txHash: swap.sourceTxHash,
+      timestamp,
+      from: addressOrPlaceholder(swap.trader),
+      to: UNKNOWN_ADDRESS,
+      token: normalizeToken(swap.fromTokenAddress),
+      amountUsd,
+      isDeposit: true,
+    });
+  }
+
+  if (destinationSlug && swap.fulfillTxHash) {
+    legs.push({
+      chain: destinationSlug,
+      // Aggregation prices tokens by origin chain when the address alone cannot identify one.
+      originChain: sourceSlug ?? null,
+      txHash: swap.fulfillTxHash,
+      timestamp,
+      from: UNKNOWN_ADDRESS,
+      to: addressOrPlaceholder(swap.destAddress),
+      token: normalizeToken(swap.toTokenAddress),
+      amountUsd,
+      isDeposit: false,
+    });
+  }
+
+  return { legs, unmappedChainIds, pricedFromSource, priceConflict };
+};
+
+export type IngestWindow = {
+  fromMs: number;
+  /** The requested window reached further back than paging can, so part of it stays uncovered. */
+  unreachableGap: boolean;
+};
+
+/**
+ * Start of the window to ingest: an overlap behind the checkpoint, clamped to reachable depth. With
+ * nothing stored there is no gap to close, so a first run simply takes the full reachable window.
+ */
+export const resolveIngestWindow = (checkpointMs: number | null, nowMs: number): IngestWindow => {
+  const earliestReachable = nowMs - MAX_LOOKBACK_MS;
+  const requested = checkpointMs ? checkpointMs - CHECKPOINT_OVERLAP_MS : earliestReachable;
+  return { fromMs: Math.max(requested, earliestReachable), unreachableGap: requested < earliestReachable };
+};
+
+/** Row as stored in `bridges.transactions`. */
+export type TransactionRow = {
+  bridge_id: string;
+  chain: string;
+  tx_hash: string;
+  ts: number;
+  tx_block: null;
+  tx_from: string;
+  tx_to: string;
+  token: string;
+  amount: string;
+  is_deposit: boolean;
+  is_usd_volume: true;
+  txs_counted_as: number;
+  origin_chain: string | null;
+};
+
+/**
+ * The table's unique key, plus `is_deposit`. The constraint itself is direction-blind, so a deposit
+ * and a withdrawal that agreed on every other column would collide in Postgres; keeping them apart
+ * here means the accumulator never sums two legs that represent opposite flows.
+ */
+const rowKey = (row: TransactionRow): string =>
+  `${row.bridge_id}-${row.chain}-${row.tx_hash}-${row.token}-${row.tx_from}-${row.tx_to}-${row.is_deposit}`;
+
+/**
+ * Accumulates rows for one run, collapsing them onto the table's unique key. Swaps batched into one
+ * transaction share a key and would otherwise overwrite each other, while the service split re-reads
+ * swaps the first pass already saw. Keying the inner map by swap handles both: distinct swaps sum,
+ * repeat sightings replace.
+ */
+export const createRowAccumulator = () => {
+  const rows = new Map<string, { row: TransactionRow; amountsBySwap: Map<string, number> }>();
+
+  return {
+    add(row: TransactionRow, swapId: string) {
+      const key = rowKey(row);
+      const existing = rows.get(key);
+      if (!existing) {
+        rows.set(key, { row: { ...row }, amountsBySwap: new Map([[swapId, Number(row.amount)]]) });
+        return;
+      }
+      existing.amountsBySwap.set(swapId, Number(row.amount));
+      existing.row.ts = Math.max(existing.row.ts, row.ts);
+    },
+    get size() {
+      return rows.size;
+    },
+    /** Rows with their per-swap values summed and the swap count carried into `txs_counted_as`. */
+    drain(): TransactionRow[] {
+      const drained = [...rows.values()].map(({ row, amountsBySwap }) => ({
+        ...row,
+        amount: [...amountsBySwap.values()].reduce((total, amount) => total + amount, 0).toFixed(2),
+        txs_counted_as: amountsBySwap.size,
+      }));
+      rows.clear();
+      return drained;
+    },
+  };
+};
+
+/** A slice of the feed to walk: one source chain, optionally narrowed to a single service. */
+export type Partition = { fromChain: string; service?: string };
+
+export const partitionLabel = ({ fromChain, service }: Partition): string =>
+  service ? `${fromChain}/${service}` : fromChain;
+
+const explorerUrl = (): string => process.env.MAYAN_EXPLORER_URL || DEFAULT_EXPLORER_URL;
+
+export const buildSwapsUrl = (partition: Partition, offset: number, baseUrl = explorerUrl()): string => {
+  const url = new URL(baseUrl);
+  url.searchParams.set("fromChain", partition.fromChain);
+  if (partition.service) url.searchParams.set("service", partition.service);
+  url.searchParams.set("limit", String(PAGE_SIZE));
+  url.searchParams.set("offset", String(offset));
+  url.searchParams.set("format", "raw");
+  return url.toString();
+};
+
+const retryDelayMs = (attempt: number): number => Math.min(RETRY_BASE_MS * 2 ** attempt, RETRY_MAX_MS);
+
+type RetryableResponse = { headers?: { get?: (name: string) => string | null } };
+
+const retryAfterMs = (response: RetryableResponse, attempt: number): number => {
+  const retryAfter = Number(response.headers?.get?.("retry-after"));
+  // Clamped: an hour-long Retry-After would park the partition well past the job's own budget.
+  return Number.isFinite(retryAfter) && retryAfter > 0
+    ? Math.min(retryAfter * 1000, RETRY_MAX_MS)
+    : retryDelayMs(attempt);
+};
+
+const fetchPage = async (
+  partition: Partition,
+  offset: number,
+  signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch
+): Promise<MayanSwap[]> => {
+  const url = buildSwapsUrl(partition, offset);
+
+  for (let attempt = 0; attempt <= REQUEST_RETRIES; attempt++) {
+    throwIfAborted(signal);
     try {
-      const url = `https://dlapi.wormhole.com/swaps?startTs=${startMs}&endTs=${endMs}&offset=${offset}&limit=${BATCH_SIZE}`;
-
-      const response = await fetch(url, {
-        headers: {
-          "API-KEY": API_KEY,
-          "Content-Type": "application/json",
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`API request failed with status: ${response.status}`);
+      // Cast: @types/node-fetch declares its own AbortSignal, structurally older than the DOM one.
+      const response = await fetchImpl(url, { timeout: REQUEST_TIMEOUT_MS, signal } as any);
+      if (response.ok) {
+        const body: any = await response.json();
+        if (!Array.isArray(body?.data)) {
+          throw new NonRetryableError(`Mayan explorer returned an unexpected payload for ${url}`);
+        }
+        return body.data as MayanSwap[];
       }
 
-      const result = await response.json();
-
-      if (result.length === 0) {
-        break;
+      await response.text().catch(() => {}); // release the socket before retrying
+      const isTransient = response.status === 429 || response.status >= 500;
+      if (!isTransient) {
+        throw new NonRetryableError(`Mayan explorer responded ${response.status} for ${url}`);
       }
-
-      const normalizedBatch = result.map((row: any) => {
-        // Parse timestamp - handle both ISO string and unix formats
-        const timestamp = row.ts ? dayjs(row.ts).unix() : dayjs().unix();
-
-        // Map chain IDs to chain names
-        const sourceChain = wormholeChainMap[row.originChain] || row.originChain || "unknown";
-        const destChain = wormholeChainMap[row.chain] || row.chain || "unknown";
-
-        // Parse USD amount
-        const usdAmount = parseFloat(row.amountUsd || "0") || 0;
-
-        return {
-          block_timestamp: timestamp,
-          transaction_hash: row.txHash || row.orderId || "",
-          token_transfer_from_address: row.txFrom || "",
-          token_transfer_to_address: row.txTo || "",
-          token_address: row.token || "",
-          token_usd_amount: String(usdAmount),
-          token_amount: row.amount || "0",
-          source_chain: sourceChain,
-          destination_chain: destChain,
-          is_deposit: row.isDeposit, // Include deposit flag for filtering in handler
-        };
-      });
-
-      allResults = [...allResults, ...normalizedBatch];
-
-      offset += BATCH_SIZE;
-
-      if (result.length < BATCH_SIZE) {
-        break;
+      if (attempt === REQUEST_RETRIES) {
+        throw new Error(`Mayan explorer responded ${response.status} for ${url} after ${attempt + 1} attempts`);
       }
+      const delay = retryAfterMs(response, attempt);
+      console.warn(`[mayan] HTTP ${response.status} for ${url}; retrying in ${Math.round(delay / 1000)}s`);
+      await waitWithSignal(delay, signal);
     } catch (error) {
-      throw error;
+      if (error instanceof NonRetryableError || isAbortError(error)) throw error;
+      if (attempt === REQUEST_RETRIES) throw error;
+      const delay = retryDelayMs(attempt);
+      console.warn(
+        `[mayan] ${(error as any)?.type ?? (error as Error)?.name ?? "network"} error for ${url}; ` +
+          `retrying in ${Math.round(delay / 1000)}s (${attempt + 1}/${REQUEST_RETRIES})`
+      );
+      await waitWithSignal(delay, signal);
     }
   }
 
-  return allResults;
+  throw new Error(`Mayan explorer paging exhausted its retries for ${url}`);
 };
 
-const adapter = chains.reduce((acc: any, chain: string) => {
-  acc[chain] = true;
-  return acc;
-}, {});
+export type PagingResult = {
+  partition: Partition;
+  pages: number;
+  swaps: number;
+  /**
+   * The offset cap was reached while swaps were still newer than the window start, so the partition
+   * covers only part of the window and has to be split further.
+   */
+  truncated: boolean;
+  /** The run's time budget ran out mid-walk, so this partition is only partly read. */
+  expired: boolean;
+  oldestSeen: number | null;
+};
+
+/**
+ * The explorer offers no time filter without a privileged pass, so a window is covered by walking
+ * the newest-first feed until it predates `fromMs`. Because the offset cap applies per query, the
+ * walk is partitioned: one query per source chain, and a busy chain split again by service.
+ */
+export const forEachPage = async (
+  partition: Partition,
+  fromMs: number,
+  onPage: (swaps: MayanSwap[]) => Promise<void>,
+  signal?: AbortSignal,
+  fetchImpl: typeof fetch = fetch,
+  isExpired: () => boolean = () => false
+): Promise<PagingResult> => {
+  let offset = 0;
+  let pages = 0;
+  let swaps = 0;
+  let oldestSeen: number | null = null;
+  const result = (truncated: boolean, expired = false): PagingResult => ({
+    partition,
+    pages,
+    swaps,
+    truncated,
+    expired,
+    oldestSeen,
+  });
+
+  while (true) {
+    throwIfAborted(signal);
+    // A partition can outlive the job's budget on its own, so the deadline is checked between pages
+    // rather than only on entry.
+    if (isExpired()) return result(false, true);
+    const page = await fetchPage(partition, offset, signal, fetchImpl);
+    pages++;
+    if (page.length === 0) return result(false);
+
+    swaps += page.length;
+    await onPage(page);
+
+    const timestamps = page
+      .map((swap) => Date.parse(swap.initiatedAt ?? ""))
+      .filter((timestamp) => Number.isFinite(timestamp) && timestamp > 0);
+    const oldestOnPage = timestamps.length ? Math.min(...timestamps) : null;
+    if (oldestOnPage !== null && (oldestSeen === null || oldestOnPage < oldestSeen)) oldestSeen = oldestOnPage;
+
+    const reachedWindowStart = oldestOnPage !== null && oldestOnPage < fromMs;
+    if (reachedWindowStart || page.length < PAGE_SIZE) return result(false);
+
+    offset += PAGE_SIZE;
+    if (offset > MAX_OFFSET) return result(true);
+  }
+};
+
+/**
+ * Chain set this bridge reports on, mirroring the Mayan entry in bridgeNetworkData. `runMayan` does
+ * the fetching, so these exist only to declare the chains that need a `bridges.config` row. They
+ * throw rather than return data: the generic runner must never reach them while "mayan" is in
+ * `bridgesToSkip` (src/utils/bridgePolicy.ts), and if it ever does the reason should be legible.
+ */
+const notRunnable = (chain: string) => async (): Promise<EventData[]> => {
+  throw new Error(
+    `Mayan is ingested by the runMayan handler, so its adapter cannot fetch ${chain}. ` +
+      `Keep "mayan" in bridgesToSkip.`
+  );
+};
+
+const adapter: BridgeAdapter = Object.fromEntries(CHAINS.map((chain) => [chain.slug, notRunnable(chain.slug)]));
 
 export default adapter;

--- a/src/data/bridgeNetworkData.ts
+++ b/src/data/bridgeNetworkData.ts
@@ -2806,6 +2806,7 @@ export default [
       "Aptos",
       "Linea",
       "Monad",
+      "Hyperliquid",
     ],
   },
   {

--- a/src/handlers/mayanApi.test.ts
+++ b/src/handlers/mayanApi.test.ts
@@ -1,0 +1,446 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import fetch from "node-fetch";
+import {
+  buildSwapsUrl,
+  servicesForChain,
+  forEachPage,
+  createRowAccumulator,
+  normalizeSwap,
+  partitionLabel,
+  resolveIngestWindow,
+  sourceChainNames,
+  MayanSwap,
+  TransactionRow,
+} from "../adapters/mayan";
+
+const EXPLORER_URL = "https://explorer-api.mayan.finance/v3/swaps";
+const HOUR_MS = 60 * 60 * 1000;
+
+const makeSwap = (overrides: Partial<MayanSwap> = {}): MayanSwap => ({
+  orderId: "SWIFT_V2_0xorder",
+  service: "SWIFT_V2",
+  status: "ORDER_SETTLED",
+  initiatedAt: "2026-08-20T12:00:00.000Z",
+  trader: "0xtrader",
+  destAddress: "SoLdEsTiNaTiOn",
+  sourceTxHash: "0xsource",
+  fulfillTxHash: "fulfillhash",
+  sourceChain: "30",
+  destChain: "1",
+  fromAmount: "0.5",
+  fromTokenAddress: "0x0000000000000000000000000000000000000000",
+  fromTokenPrice: 4000,
+  toAmount: "20",
+  toTokenAddress: "0x0000000000000000000000000000000000000000",
+  toTokenPrice: 100,
+  ...overrides,
+});
+
+/** node-fetch stand-in serving the given pages in order and recording the URLs requested. */
+const makeFetchImpl = (pages: MayanSwap[][], requested: string[] = []) => {
+  let call = 0;
+  const impl = async (url: any) => {
+    requested.push(String(url));
+    const page = pages[call] ?? [];
+    call += 1;
+    return { ok: true, json: async () => ({ data: page }) };
+  };
+  return impl as unknown as typeof fetch;
+};
+
+const makePage = (size: number, initiatedAt: string): MayanSwap[] =>
+  Array.from({ length: size }, (_, index) => makeSwap({ sourceTxHash: `0x${initiatedAt}${index}`, initiatedAt }));
+
+const makeRow = (overrides: Partial<TransactionRow> = {}): TransactionRow => ({
+  bridge_id: "bridge-1",
+  chain: "base",
+  tx_hash: "0xshared",
+  ts: 1_000,
+  tx_block: null,
+  tx_from: "0xtrader",
+  tx_to: "0x",
+  token: "0xtoken",
+  amount: "100.00",
+  is_deposit: true,
+  is_usd_volume: true,
+  txs_counted_as: 1,
+  origin_chain: null,
+  ...overrides,
+});
+
+test("a settled swap yields a deposit leg on the source chain and a withdrawal leg on the destination", () => {
+  const { legs, skipped, pricedFromSource, priceConflict } = normalizeSwap(makeSwap());
+  const [deposit, withdrawal] = legs;
+
+  assert.equal(skipped, undefined);
+  assert.equal(pricedFromSource, false);
+  assert.equal(priceConflict, false);
+
+  assert.deepEqual(deposit, {
+    chain: "base",
+    originChain: null,
+    txHash: "0xsource",
+    timestamp: Date.parse("2026-08-20T12:00:00.000Z"),
+    from: "0xtrader",
+    to: "0x",
+    token: "0x0000000000000000000000000000000000000000",
+    amountUsd: "2000.00",
+    isDeposit: true,
+  });
+  assert.deepEqual(withdrawal, {
+    chain: "solana",
+    originChain: "base",
+    txHash: "fulfillhash",
+    timestamp: Date.parse("2026-08-20T12:00:00.000Z"),
+    from: "0x",
+    to: "SoLdEsTiNaTiOn",
+    token: "0x0000000000000000000000000000000000000000",
+    amountUsd: "2000.00",
+    isDeposit: false,
+  });
+});
+
+test("an overstated source price cannot inflate volume", () => {
+  // Long-tail inputs carry the price of the stable leg Mayan routed through: 496bn units at ~$1.
+  const { legs, priceConflict } = normalizeSwap(
+    makeSwap({ fromAmount: "496499999999.99", fromTokenPrice: 0.99927984, toAmount: "39.1", toTokenPrice: 0.99927984 })
+  );
+
+  assert.equal(priceConflict, true);
+  assert.deepEqual(
+    legs.map((leg) => leg.amountUsd),
+    ["39.07", "39.07"]
+  );
+});
+
+test("an overstated destination price cannot inflate volume", () => {
+  const { legs, priceConflict } = normalizeSwap(
+    makeSwap({ fromAmount: "0.002078", fromTokenPrice: 2308.24, toAmount: "1e35", toTokenPrice: 1.141 })
+  );
+
+  assert.equal(priceConflict, true);
+  assert.equal(legs[0].amountUsd, "4.80");
+});
+
+test("corroborated prices are kept whatever their size", () => {
+  const { legs, priceConflict } = normalizeSwap(
+    makeSwap({ fromAmount: "20000000", fromTokenPrice: 1, toAmount: "19990000", toTokenPrice: 1 })
+  );
+
+  assert.equal(priceConflict, false);
+  assert.equal(legs[0].amountUsd, "19990000.00");
+});
+
+test("the source side prices a swap only when the destination side cannot", () => {
+  const { legs, pricedFromSource } = normalizeSwap(makeSwap({ toTokenPrice: null }));
+
+  assert.equal(pricedFromSource, true);
+  assert.equal(legs[0].amountUsd, "2000.00");
+});
+
+test("a source-only price may not assert an implausible value", () => {
+  const capped = normalizeSwap(makeSwap({ toTokenPrice: null, fromAmount: "2000000", fromTokenPrice: 1 }));
+  assert.equal(capped.skipped, "uncorroborated");
+  assert.deepEqual(capped.legs, []);
+
+  // Under the ceiling the swap still counts: source-only pricing is normal for HyperCore legs.
+  const kept = normalizeSwap(makeSwap({ toTokenPrice: null, fromAmount: "100000", fromTokenPrice: 1 }));
+  assert.equal(kept.skipped, undefined);
+  assert.equal(kept.legs[0].amountUsd, "100000.00");
+});
+
+test("a destination-only price is not capped, since large swaps are legitimate", () => {
+  const { skipped, legs } = normalizeSwap(makeSwap({ fromTokenPrice: null, toAmount: "2000000", toTokenPrice: 1 }));
+
+  assert.equal(skipped, undefined);
+  assert.equal(legs[0].amountUsd, "2000000.00");
+});
+
+test("a swap with no usable price on either side is skipped", () => {
+  const { legs, skipped } = normalizeSwap(makeSwap({ fromTokenPrice: null, toTokenPrice: 0 }));
+
+  assert.equal(skipped, "unpriced");
+  assert.deepEqual(legs, []);
+});
+
+test("swaps that never settled are skipped", () => {
+  for (const status of ["ORDER_REFUNDED", "ORDER_CREATED", "ORDER_EXPIRED", "REFUNDED_ON_EVM_MCTP"]) {
+    const { legs, skipped } = normalizeSwap(makeSwap({ status }));
+
+    assert.equal(skipped, "unsettled", status);
+    assert.deepEqual(legs, [], status);
+  }
+});
+
+test("a Wormhole bridge redeem still in flight is not settled, but the same status settles elsewhere", () => {
+  assert.equal(normalizeSwap(makeSwap({ status: "REDEEM_VAA_SIGNED", service: "WH_BRIDGE" })).skipped, "unsettled");
+  assert.equal(normalizeSwap(makeSwap({ status: "REDEEM_VAA_SIGNED", service: "MCTP_SWAP" })).skipped, undefined);
+});
+
+test("a Swift order awaiting its HyperCore deposit is not settled until the deposit lands", () => {
+  const pending = makeSwap({ status: "ORDER_SETTLED", service: "SWIFT_V2", meta: { hypercoreData: {} } });
+  assert.equal(normalizeSwap(pending).skipped, "unsettled");
+
+  const landed = makeSwap({
+    status: "ORDER_SETTLED",
+    service: "SWIFT_V2",
+    meta: { hypercoreData: { redeemTxHash: "0xdeposit" } },
+  });
+  assert.equal(normalizeSwap(landed).skipped, undefined);
+});
+
+test("same-chain swaps are out of scope for a cross-chain series", () => {
+  const { legs, skipped } = normalizeSwap(makeSwap({ sourceChain: "2", destChain: "2" }));
+
+  assert.equal(skipped, "same_chain");
+  assert.deepEqual(legs, []);
+});
+
+test("HyperEVM and HyperCore are one chain, so value moving between them is not bridged", () => {
+  const { legs, skipped } = normalizeSwap(makeSwap({ sourceChain: "47", destChain: "65000" }));
+
+  assert.equal(skipped, "same_chain");
+  assert.deepEqual(legs, []);
+});
+
+test("legs worth less than a cent are skipped rather than stored as zero", () => {
+  const { legs, skipped } = normalizeSwap(makeSwap({ toAmount: "0.000001", toTokenPrice: 1, fromTokenPrice: null }));
+
+  assert.equal(skipped, "unpriced");
+  assert.deepEqual(legs, []);
+});
+
+test("only canonical EVM addresses are case-folded", () => {
+  const evm = normalizeSwap(
+    makeSwap({ fromTokenAddress: "0xAbCdEf0123456789000000000000000000000001", toTokenAddress: "SoLtOkEnAddr" })
+  );
+  assert.equal(evm.legs[0].token, "0xabcdef0123456789000000000000000000000001");
+  assert.equal(evm.legs[1].token, "SoLtOkEnAddr");
+
+  // Sui coin types are 0x-prefixed but their module and struct names are case-sensitive.
+  const sui = normalizeSwap(
+    makeSwap({
+      fromTokenAddress: "0x2::sui::SUI",
+      toTokenAddress: "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC",
+    })
+  );
+  assert.equal(sui.legs[0].token, "0x2::sui::SUI");
+  assert.equal(sui.legs[1].token, "0xdba34672e30cb065b1f93e3ab55318768fd6fef66c15942c9f7cb846e2f900e7::usdc::USDC");
+});
+
+test("HyperEVM and HyperCore both report as the Hyperliquid chain", () => {
+  const { legs } = normalizeSwap(makeSwap({ sourceChain: "47", destChain: "2" }));
+
+  assert.equal(legs[0].chain, "hyperliquid");
+  assert.ok(sourceChainNames.includes("hyperevm"));
+  assert.ok(sourceChainNames.includes("hypercore"));
+});
+
+test("an unmapped chain id is reported and its counterpart leg still counts", () => {
+  const { legs, unmappedChainIds } = normalizeSwap(makeSwap({ destChain: "9999" }));
+
+  assert.deepEqual(unmappedChainIds, ["9999"]);
+  assert.deepEqual(
+    legs.map((leg) => leg.isDeposit),
+    [true]
+  );
+});
+
+test("a leg without a transaction hash is omitted", () => {
+  const { legs } = normalizeSwap(makeSwap({ sourceTxHash: null }));
+
+  assert.deepEqual(
+    legs.map((leg) => leg.isDeposit),
+    [false]
+  );
+});
+
+test("a chain is only split by services it actually runs", () => {
+  // The API answers an empty (chain, service) filter with a full table traversal, so combinations
+  // that have never existed must not be queried. BSC settles no MCTP at all.
+  assert.deepEqual(
+    servicesForChain("bsc").filter((service) => service.startsWith("MCTP")),
+    []
+  );
+  assert.deepEqual(servicesForChain("hypercore"), ["HC_WITHDRAW"]);
+  assert.deepEqual(servicesForChain("aptos"), []);
+  assert.deepEqual(servicesForChain("nonexistent"), []);
+  assert.ok(servicesForChain("solana").includes("SWIFT_V2"));
+});
+
+test("buildSwapsUrl partitions by source chain within the API page limit", () => {
+  const url = new URL(buildSwapsUrl({ fromChain: "solana" }, 200, EXPLORER_URL));
+
+  // Raw rows only: the presentation shape mis-prices forwarded source legs.
+  assert.equal(url.searchParams.get("format"), "raw");
+  assert.equal(url.searchParams.get("fromChain"), "solana");
+  assert.equal(url.searchParams.get("offset"), "200");
+  assert.equal(url.searchParams.get("service"), null);
+  assert.ok(Number(url.searchParams.get("limit")) <= 100);
+});
+
+test("buildSwapsUrl narrows a partition to one service", () => {
+  const partition = { fromChain: "ethereum", service: "SWIFT_V2" };
+  const url = new URL(buildSwapsUrl(partition, 0, EXPLORER_URL));
+
+  assert.equal(url.searchParams.get("service"), "SWIFT_V2");
+  assert.equal(partitionLabel(partition), "ethereum/SWIFT_V2");
+  assert.equal(partitionLabel({ fromChain: "ethereum" }), "ethereum");
+});
+
+test("paging stops on the page that reaches back past the window start", async () => {
+  const requested: string[] = [];
+  const fetchImpl = makeFetchImpl(
+    [
+      makePage(100, "2026-08-20T12:00:00.000Z"),
+      makePage(100, "2026-08-19T23:00:00.000Z"),
+      makePage(100, "2026-08-18T00:00:00.000Z"),
+    ],
+    requested
+  );
+  const seen: MayanSwap[] = [];
+
+  const result = await forEachPage(
+    { fromChain: "base" },
+    Date.parse("2026-08-20T00:00:00.000Z"),
+    async (swaps: MayanSwap[]) => {
+      seen.push(...swaps);
+    },
+    undefined,
+    fetchImpl
+  );
+
+  assert.equal(result.pages, 2);
+  assert.equal(result.swaps, 200);
+  assert.equal(result.truncated, false);
+  assert.equal(seen.length, 200);
+  assert.deepEqual(
+    requested.map((url) => new URL(url).searchParams.get("offset")),
+    ["0", "100"]
+  );
+});
+
+test("paging stops on a partial page", async () => {
+  const result = await forEachPage(
+    { fromChain: "linea" },
+    Date.parse("2026-08-01T00:00:00.000Z"),
+    async () => {},
+    undefined,
+    makeFetchImpl([makePage(10, "2026-08-20T12:00:00.000Z")])
+  );
+
+  assert.equal(result.pages, 1);
+  assert.equal(result.truncated, false);
+});
+
+test("a partition that outlives the run's budget stops and reports it", async () => {
+  const pages = Array.from({ length: 10 }, () => makePage(100, "2026-08-20T12:00:00.000Z"));
+  let calls = 0;
+
+  const result = await forEachPage(
+    { fromChain: "solana" },
+    Date.parse("2026-08-01T00:00:00.000Z"),
+    async () => {},
+    undefined,
+    makeFetchImpl(pages),
+    () => ++calls > 3
+  );
+
+  assert.equal(result.expired, true);
+  assert.equal(result.truncated, false);
+  assert.equal(result.pages, 3);
+});
+
+test("exhausting the offset cap is reported as truncation rather than full coverage", async () => {
+  const pages = Array.from({ length: 64 }, () => makePage(100, "2026-08-20T12:00:00.000Z"));
+
+  const result = await forEachPage(
+    { fromChain: "solana" },
+    Date.parse("2026-08-01T00:00:00.000Z"),
+    async () => {},
+    undefined,
+    makeFetchImpl(pages)
+  );
+
+  assert.equal(result.truncated, true);
+  // Offsets 0 through the 3000 cap, after which the next request would be rejected.
+  assert.equal(result.pages, 31);
+});
+
+test("distinct swaps sharing a transaction are summed, not dropped", () => {
+  const accumulator = createRowAccumulator();
+  accumulator.add(makeRow(), "swap-a");
+  accumulator.add(makeRow({ amount: "50.25", ts: 2_000 }), "swap-b");
+  const [row] = accumulator.drain();
+
+  assert.equal(row.amount, "150.25");
+  assert.equal(row.txs_counted_as, 2);
+  assert.equal(row.ts, 2_000);
+});
+
+test("re-reading one swap in a later pass replaces it rather than doubling it", () => {
+  const accumulator = createRowAccumulator();
+  accumulator.add(makeRow(), "swap-a");
+  accumulator.add(makeRow(), "swap-a");
+  const [row] = accumulator.drain();
+
+  assert.equal(row.amount, "100.00");
+  assert.equal(row.txs_counted_as, 1);
+});
+
+test("rows differing in any key column stay separate", () => {
+  const accumulator = createRowAccumulator();
+  accumulator.add(makeRow(), "swap-a");
+  accumulator.add(makeRow({ chain: "solana" }), "swap-b");
+  accumulator.add(makeRow({ tx_hash: "0xother" }), "swap-c");
+
+  assert.equal(accumulator.drain().length, 3);
+});
+
+test("legs in opposite directions are never summed together", () => {
+  const accumulator = createRowAccumulator();
+  accumulator.add(makeRow(), "swap-a");
+  accumulator.add(makeRow({ is_deposit: false }), "swap-b");
+  const drained = accumulator.drain();
+
+  assert.equal(drained.length, 2);
+  assert.deepEqual(
+    drained.map((row) => row.amount),
+    ["100.00", "100.00"]
+  );
+});
+
+test("draining empties the accumulator", () => {
+  const accumulator = createRowAccumulator();
+  accumulator.add(makeRow(), "swap-a");
+
+  assert.equal(accumulator.drain().length, 1);
+  assert.equal(accumulator.drain().length, 0);
+});
+
+test("the ingest window resumes an overlap behind the checkpoint", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+  const checkpoint = now - 3 * HOUR_MS;
+
+  // The overlap has to exceed how long a swap can take to settle, since the feed orders by initiation.
+  assert.deepEqual(resolveIngestWindow(checkpoint, now), {
+    fromMs: checkpoint - 2 * HOUR_MS,
+    unreachableGap: false,
+  });
+});
+
+test("a first run takes the whole reachable window and reports no gap", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+
+  assert.deepEqual(resolveIngestWindow(null, now), { fromMs: now - 12 * HOUR_MS, unreachableGap: false });
+});
+
+test("a checkpoint beyond reachable depth is clamped and flagged", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+
+  assert.deepEqual(resolveIngestWindow(now - 30 * 24 * HOUR_MS, now), {
+    fromMs: now - 12 * HOUR_MS,
+    unreachableGap: true,
+  });
+});

--- a/src/handlers/mayanApi.test.ts
+++ b/src/handlers/mayanApi.test.ts
@@ -4,6 +4,7 @@ import fetch from "node-fetch";
 import {
   buildSwapsUrl,
   servicesForChain,
+  servicesToSplit,
   forEachPage,
   createRowAccumulator,
   normalizeSwap,
@@ -269,6 +270,13 @@ test("a chain is only split by services it actually runs", () => {
   assert.ok(servicesForChain("solana").includes("SWIFT_V2"));
 });
 
+test("a split covers services the walk observed beyond the static table", () => {
+  assert.deepEqual(servicesToSplit("bsc", ["WH_BRIDGE", "SWIFT_V2"]).sort(), ["SWIFT_V2", "WH_BRIDGE"]);
+  assert.ok(servicesToSplit("solana").includes("SWIFT_V2"));
+  assert.ok(!servicesToSplit("base", ["MONO_CHAIN"]).includes("MONO_CHAIN"));
+  assert.deepEqual(servicesToSplit("aptos", ["WH_BRIDGE"]), ["WH_BRIDGE"]);
+});
+
 test("buildSwapsUrl partitions by source chain within the API page limit", () => {
   const url = new URL(buildSwapsUrl({ fromChain: "solana" }, 200, EXPLORER_URL));
 
@@ -434,6 +442,15 @@ test("a first run takes the whole reachable window and reports no gap", () => {
   const now = Date.parse("2026-08-20T12:00:00.000Z");
 
   assert.deepEqual(resolveIngestWindow(null, now), { fromMs: now - 12 * HOUR_MS, unreachableGap: false });
+});
+
+test("a checkpoint ahead of the clock cannot push the window into the future", () => {
+  const now = Date.parse("2026-08-20T12:00:00.000Z");
+
+  assert.deepEqual(resolveIngestWindow(now + 5 * HOUR_MS, now), {
+    fromMs: now - 2 * HOUR_MS,
+    unreachableGap: false,
+  });
 });
 
 test("a checkpoint beyond reachable depth is clamped and flagged", () => {

--- a/src/handlers/runMayan.ts
+++ b/src/handlers/runMayan.ts
@@ -7,7 +7,7 @@ import adapter, {
   PagingResult,
   Partition,
   partitionLabel,
-  servicesForChain,
+  servicesToSplit,
   resolveIngestWindow,
   sourceChainNames,
   SwapLeg,
@@ -220,6 +220,8 @@ export const handler = async (signal?: AbortSignal) => {
 
   const isExpired = () => Date.now() - startedAt > TIME_BUDGET_MS;
 
+  const observedServices = new Map<string, Set<string>>();
+
   const ingestPartition = async (partition: Partition): Promise<PagingResult> => {
     if (isExpired()) {
       diagnostics.skippedPartitions.push(partitionLabel(partition));
@@ -230,7 +232,12 @@ export const handler = async (signal?: AbortSignal) => {
     const result = await forEachPage(
       partition,
       fromMs,
-      async (swaps) => collectRows(swaps),
+      async (swaps) => {
+        let services = observedServices.get(partition.fromChain);
+        if (!services) observedServices.set(partition.fromChain, (services = new Set()));
+        for (const swap of swaps) if (swap.service) services.add(swap.service);
+        collectRows(swaps);
+      },
       signal,
       undefined,
       isExpired
@@ -266,7 +273,7 @@ export const handler = async (signal?: AbortSignal) => {
     await writeRows(rows);
   };
 
-  let stillTruncated: string[] = [];
+  const stillTruncated: string[] = [];
   try {
     const chainResults = await ingestPartitions(sourceChainNames.map((fromChain) => ({ fromChain })));
 
@@ -277,18 +284,22 @@ export const handler = async (signal?: AbortSignal) => {
       .map(({ partition }) => partition.fromChain);
     if (truncatedChains.length > 0) {
       console.log(`Splitting ${truncatedChains.join(", ")} by service after hitting the offset cap.`);
-      // Split only by services the chain runs: querying a combination with no swaps is slow enough
-      // to exhaust its retries.
-      const serviceResults = await ingestPartitions(
-        truncatedChains.flatMap((fromChain) => servicesForChain(fromChain).map((service) => ({ fromChain, service })))
+      // Split only by services the chain was seen or is known to run: querying a combination with no
+      // swaps is slow enough to exhaust its retries.
+      const servicePartitions: Partition[] = [];
+      for (const fromChain of truncatedChains) {
+        const services = servicesToSplit(fromChain, observedServices.get(fromChain) ?? []);
+        if (services.length === 0) stillTruncated.push(fromChain);
+        else servicePartitions.push(...services.map((service) => ({ fromChain, service })));
+      }
+      const serviceResults = servicePartitions.length > 0 ? await ingestPartitions(servicePartitions) : [];
+      stillTruncated.push(
+        ...serviceResults.filter(({ truncated }) => truncated).map(({ partition }) => partitionLabel(partition))
       );
-      stillTruncated = serviceResults
-        .filter(({ truncated }) => truncated)
-        .map(({ partition }) => partitionLabel(partition));
       if (stillTruncated.length > 0) {
         console.warn(
-          `[WARN] ${stillTruncated.join(", ")} remain truncated after the service split; they cover only ` +
-            `back to the oldest page logged above.`
+          `[WARN] ${stillTruncated.join(", ")} remain truncated after the service split; this run covers ` +
+            `only back to the oldest page logged above, and the checkpoint is held back for a re-read.`
         );
       }
     }
@@ -298,9 +309,8 @@ export const handler = async (signal?: AbortSignal) => {
 
   reportDiagnostics(diagnostics);
 
-  // Only a partition stopped by the time budget holds the checkpoint back, since only that one
-  // benefits from a retry; a truncated partition would stop at the same place every time.
-  if (diagnostics.skippedPartitions.length === 0) {
+  // An incomplete pass holds the checkpoint back, whether it ran out of time or hit the offset cap.
+  if (diagnostics.skippedPartitions.length === 0 && stillTruncated.length === 0) {
     await saveCheckpoint(startedAt);
   } else {
     console.warn(`[WARN] Mayan checkpoint held back; the next run repeats from ${new Date(fromMs).toISOString()}.`);

--- a/src/handlers/runMayan.ts
+++ b/src/handlers/runMayan.ts
@@ -1,135 +1,314 @@
-import { wrapScheduledLambda } from "../utils/wrap";
-import adapter, { fetchMayanEvents, normalizeChainName } from "../adapters/mayan";
-import { sql } from "../utils/db";
-import { insertTransactionRows } from "../utils/wrappa/postgres/write";
-import { getBridgeID } from "../utils/wrappa/postgres/query";
-import dayjs from "dayjs";
+import { PromisePool } from "@supercharge/promise-pool";
+import adapter, {
+  createRowAccumulator,
+  forEachPage,
+  MayanSwap,
+  normalizeSwap,
+  PagingResult,
+  Partition,
+  partitionLabel,
+  servicesForChain,
+  resolveIngestWindow,
+  sourceChainNames,
+  SwapLeg,
+  SwapSkipReason,
+  TransactionRow,
+  VOLUME_WINDOW_MS,
+} from "../adapters/mayan";
 import { insertConfigEntriesForAdapter } from "../utils/adapter";
-import { setCache } from "../utils/cache";
+import { advanceDurableCheckpoint, getDurableCheckpoint, setCache } from "../utils/cache";
+import { sql } from "../utils/db";
+import { formatError, NonRetryableError, throwIfAborted } from "../utils/errors";
+import { wrapScheduledLambda } from "../utils/wrap";
+import { insertTransactionRows } from "../utils/wrappa/postgres/write";
 
-const END_TS_KEY = "24h_mayan_volume";
+const BRIDGE_NAME = "mayan";
+const VOLUME_CACHE_KEY = "24h_mayan_volume";
+const CHECKPOINT_KEY = "adapter_progress:mayan:initiated_at";
+const INSERT_BATCH_SIZE = 500;
+const PARTITION_CONCURRENCY = 4;
 
-export const handler = async () => {
+/** Stop before the cron's own timeout, which would abort a partition mid-read. */
+const TIME_BUDGET_MS = 16 * 60 * 1000;
+
+const getNewestStoredMs = async (): Promise<number | null> => {
+  const [row] = await sql<Array<{ newest: string | null }>>`
+    SELECT floor(extract(epoch from max(t.ts)) * 1000)::bigint::text AS newest
+    FROM bridges.transactions t
+    JOIN bridges.config c ON c.id = t.bridge_id
+    WHERE c.bridge_name = ${BRIDGE_NAME}
+      AND t.ts <= NOW()
+  `;
+  const newest = Number(row?.newest);
+  return Number.isFinite(newest) && newest > 0 ? newest : null;
+};
+
+/**
+ * The checkpoint is held back by an incomplete run so the next one re-reads the gap. Only an
+ * unconfigured Redis falls back to the newest stored row, which cannot express incompleteness.
+ */
+const readCheckpointMs = async (): Promise<number | null> => {
   try {
-    await insertConfigEntriesForAdapter(adapter, "mayan");
-    const startTs = dayjs().subtract(24, "hour").unix();
-    const endTs = dayjs().unix();
-    const bridgeIds = Object.fromEntries(
-      await Promise.all(
-        Object.keys(adapter).map(async (chain) => {
-          chain = chain.toLowerCase();
-          const bridgeId = await getBridgeID("mayan", chain);
-          return [chain, bridgeId?.id];
-        })
-      )
-    );
-    console.log(
-      `Running Mayan adapter for ${startTs} (${dayjs.unix(startTs).format("YYYY-MM-DD HH:mm:ss")}) to ${endTs} (${dayjs
-        .unix(endTs)
-        .format("YYYY-MM-DD HH:mm:ss")})`
-    );
-    const events = await fetchMayanEvents(startTs, endTs);
-    const BATCH_SIZE = 500;
-    let bathesInserted = 1;
-
-    const processBatch = async (sql: any, batch: any[]) => {
-      const start = dayjs().unix();
-      const transactions = [];
-
-      for (const event of batch) {
-        const {
-          block_timestamp,
-          transaction_hash,
-          token_transfer_from_address,
-          token_transfer_to_address,
-          token_address,
-          token_amount,
-          token_usd_amount,
-          source_chain,
-          destination_chain,
-          is_deposit,
-        } = event;
-
-        const sourceChain = normalizeChainName(source_chain);
-        const destinationChain = normalizeChainName(destination_chain);
-
-        // Determine the correct chain to use for the bridge_id based on deposit status
-        const transactionChain = is_deposit ? destinationChain : sourceChain;
-        const originChain = is_deposit ? sourceChain : null;
-
-        const tokenAmountUsd = parseFloat(token_usd_amount) ? token_usd_amount : 0;
-        // sanity check
-        const shouldBeUSDVolume = tokenAmountUsd > 0 && tokenAmountUsd <= 10_000_000;
-
-        // Only create one transaction per event, using the appropriate chain's bridge_id
-        if (bridgeIds[transactionChain]) {
-          transactions.push({
-            bridge_id: bridgeIds[transactionChain],
-            chain: transactionChain,
-            tx_hash: transaction_hash,
-            ts: parseInt(block_timestamp) * 1000,
-            tx_block: null,
-            tx_from: token_transfer_from_address ?? "0x",
-            tx_to: token_transfer_to_address ?? "0x",
-            token: token_address ?? "0x0000000000000000000000000000000000000000",
-            amount: shouldBeUSDVolume ? tokenAmountUsd : token_amount ?? "0",
-            is_deposit: is_deposit,
-            is_usd_volume: shouldBeUSDVolume,
-            txs_counted_as: 1,
-            origin_chain: originChain,
-          });
-        }
-      }
-
-      try {
-        if (transactions.length > 0) {
-          await insertTransactionRows(sql, true, transactions, "upsert");
-        }
-      } catch (error) {
-        console.error(`Error inserting Mayan batch:`, error);
-        throw error;
-      }
-
-      console.log(
-        `Inserted ${bathesInserted} of ${Math.ceil(events.length / BATCH_SIZE)} batches in ${
-          dayjs().unix() - start
-        } seconds`
-      );
-      bathesInserted++;
-    };
-
-    let start = 0;
-    const end = events.length;
-
-    while (start < end) {
-      const batchEnd = Math.min(start + BATCH_SIZE, end);
-      await sql.begin(async (sql) => {
-        await processBatch(sql, events.slice(start, batchEnd));
-      });
-      start += BATCH_SIZE;
-    }
-    // Calculate total volume, filtering outliers and avoiding double counting
-    const totalVolume = events.reduce((acc: number, curr: any) => {
-      const amount = parseFloat(curr.token_usd_amount || "0");
-
-      // Skip transactions over $1M (outliers from API issues. Mayan's API pricing isn't perfectly reliable, a majority of the outliers are caught with this)
-      if (amount > 1_000_000) {
-        return acc;
-      }
-
-      // Only count deposits to avoid double counting (each bridge action has both deposit + withdrawal)
-      if (!curr.is_deposit) {
-        return acc;
-      }
-
-      return acc + amount;
-    }, 0);
-
-    console.log(`Mayan total volume: $${totalVolume}`);
-    await setCache(END_TS_KEY, totalVolume, null);
+    const seconds = await getDurableCheckpoint(CHECKPOINT_KEY);
+    if (seconds !== null) return seconds * 1000;
   } catch (error) {
-    throw error;
+    // Only an unconfigured Redis may fall back. When Redis exists but is unreachable, the newest
+    // stored row would silently stand in for a checkpoint that was deliberately held back, skipping
+    // the very gap the hold-back exists to re-read.
+    if (process.env.REDIS_URL) {
+      throw new NonRetryableError(`Mayan checkpoint is unreadable: ${formatError(error)}`);
+    }
+    console.warn(`[WARN] No Redis configured (${formatError(error)}); using the newest stored row instead.`);
   }
+  return getNewestStoredMs();
+};
+
+const saveCheckpoint = async (checkpointMs: number) => {
+  try {
+    await advanceDurableCheckpoint(CHECKPOINT_KEY, Math.floor(checkpointMs / 1000));
+  } catch (error) {
+    console.warn(`[WARN] Mayan checkpoint not stored (${formatError(error)}); the next run re-reads this window.`);
+  }
+};
+
+/** Read back from stored rows, so the figure holds regardless of how far the run paged. */
+const getRecentVolumeUsd = async (): Promise<{ volumeUsd: number; legs: number }> => {
+  const [row] = await sql<Array<{ volume: string; legs: string }>>`
+    SELECT COALESCE(sum(t.amount::numeric), 0)::text AS volume, count(*)::text AS legs
+    FROM bridges.transactions t
+    JOIN bridges.config c ON c.id = t.bridge_id
+    WHERE c.bridge_name = ${BRIDGE_NAME}
+      AND t.is_deposit
+      AND t.is_usd_volume
+      AND t.ts >= NOW() - ${`${VOLUME_WINDOW_MS / 1000} seconds`}::interval
+  `;
+  return { volumeUsd: Number(row?.volume ?? 0), legs: Number(row?.legs ?? 0) };
+};
+
+const getBridgeIdsByChain = async (): Promise<Record<string, string>> => {
+  const rows = await sql<Array<{ chain: string; id: string }>>`
+    SELECT chain, id::text AS id FROM bridges.config WHERE bridge_name = ${BRIDGE_NAME}
+  `;
+  return Object.fromEntries(rows.map((row) => [row.chain, row.id]));
+};
+
+const toRow = (bridgeId: string, leg: SwapLeg): TransactionRow => ({
+  bridge_id: bridgeId,
+  chain: leg.chain,
+  tx_hash: leg.txHash,
+  ts: leg.timestamp,
+  tx_block: null,
+  tx_from: leg.from,
+  tx_to: leg.to,
+  token: leg.token,
+  amount: leg.amountUsd,
+  is_deposit: leg.isDeposit,
+  is_usd_volume: true,
+  txs_counted_as: 1,
+  origin_chain: leg.originChain,
+});
+
+/** Writes rows in batches. Rows are upserted, so a repeated run is idempotent. */
+const writeRows = async (rows: TransactionRow[]) => {
+  for (let start = 0; start < rows.length; start += INSERT_BATCH_SIZE) {
+    const batch = rows.slice(start, start + INSERT_BATCH_SIZE);
+    await sql.begin(async (transaction) => {
+      await insertTransactionRows(transaction, true, batch, "upsert", true);
+    });
+  }
+};
+
+type Diagnostics = {
+  depositLegs: number;
+  withdrawalLegs: number;
+  /** Legs a settled swap could not produce, for want of a transaction hash. */
+  unroutableLegs: number;
+  skippedSwaps: Record<SwapSkipReason, number>;
+  sourcePricedSwaps: number;
+  priceConflicts: number;
+  unmappedChainIds: Set<string>;
+  skippedPartitions: string[];
+};
+
+const createDiagnostics = (): Diagnostics => ({
+  depositLegs: 0,
+  withdrawalLegs: 0,
+  unroutableLegs: 0,
+  skippedSwaps: { unsettled: 0, same_chain: 0, invalid_timestamp: 0, unpriced: 0, uncorroborated: 0 },
+  sourcePricedSwaps: 0,
+  priceConflicts: 0,
+  unmappedChainIds: new Set(),
+  skippedPartitions: [],
+});
+
+const reportDiagnostics = (diagnostics: Diagnostics) => {
+  const { unmappedChainIds, skippedPartitions, skippedSwaps } = diagnostics;
+  if (unmappedChainIds.size > 0) {
+    console.warn(
+      `[WARN] Mayan reported chain id(s) ${[...unmappedChainIds].join(", ")} with no entry in the adapter's ` +
+        `chain table; those legs are not recorded until the table is updated.`
+    );
+  }
+  if (skippedPartitions.length > 0) {
+    console.warn(
+      `[WARN] Exhausted the ${TIME_BUDGET_MS / 60_000} minute budget before reading ` +
+        `${skippedPartitions.length} partition(s): ${skippedPartitions.join(", ")}.`
+    );
+  }
+  console.log(
+    `Mayan wrote ${diagnostics.depositLegs} deposit and ${diagnostics.withdrawalLegs} withdrawal legs; ` +
+      `skipped ${skippedSwaps.unsettled} unsettled, ${skippedSwaps.same_chain} same-chain, ` +
+      `${skippedSwaps.unpriced} unpriced, ${skippedSwaps.uncorroborated} uncorroborated and ` +
+      `${skippedSwaps.invalid_timestamp} undated swaps, plus ` +
+      `${diagnostics.unroutableLegs} unroutable legs; ${diagnostics.sourcePricedSwaps} swaps priced from the ` +
+      `source side, ${diagnostics.priceConflicts} with conflicting side prices.`
+  );
+};
+
+export const handler = async (signal?: AbortSignal) => {
+  throwIfAborted(signal);
+  const startedAt = Date.now();
+
+  await insertConfigEntriesForAdapter(adapter, BRIDGE_NAME);
+  const bridgeIds = await getBridgeIdsByChain();
+
+  const checkpointMs = await readCheckpointMs();
+  const { fromMs, unreachableGap } = resolveIngestWindow(checkpointMs, startedAt);
+  if (unreachableGap) {
+    console.warn(
+      `[WARN] The Mayan checkpoint predates what the explorer API can page back to; ` +
+        `the gap before ${new Date(fromMs).toISOString()} needs a manual backfill.`
+    );
+  }
+  console.log(
+    `Ingesting Mayan swaps since ${new Date(fromMs).toISOString()} ` +
+      `(checkpoint ${checkpointMs ? new Date(checkpointMs).toISOString() : "none"})`
+  );
+
+  const diagnostics = createDiagnostics();
+  // Rows accumulate across both passes and are written once, so swaps sharing a transaction are
+  // summed rather than overwriting one another.
+  const accumulator = createRowAccumulator();
+
+  const collectRows = (swaps: MayanSwap[]) => {
+    for (const swap of swaps) {
+      const { legs, skipped, unmappedChainIds, pricedFromSource, priceConflict } = normalizeSwap(swap);
+      unmappedChainIds.forEach((chainId) => diagnostics.unmappedChainIds.add(chainId));
+      if (pricedFromSource) diagnostics.sourcePricedSwaps++;
+      if (priceConflict) diagnostics.priceConflicts++;
+      if (skipped) {
+        diagnostics.skippedSwaps[skipped]++;
+        continue;
+      }
+      diagnostics.unroutableLegs += 2 - legs.length;
+
+      for (const leg of legs) {
+        // A page can reach past the window start; only rows inside it belong to this run.
+        if (leg.timestamp < fromMs) continue;
+
+        const bridgeId = bridgeIds[leg.chain];
+        if (!bridgeId) {
+          throw new NonRetryableError(`bridges.config has no ${BRIDGE_NAME} row for chain ${leg.chain}`);
+        }
+
+        accumulator.add(toRow(bridgeId, leg), swap.orderId ?? `${leg.chain}-${leg.txHash}`);
+        if (leg.isDeposit) diagnostics.depositLegs++;
+        else diagnostics.withdrawalLegs++;
+      }
+    }
+  };
+
+  const isExpired = () => Date.now() - startedAt > TIME_BUDGET_MS;
+
+  const ingestPartition = async (partition: Partition): Promise<PagingResult> => {
+    if (isExpired()) {
+      diagnostics.skippedPartitions.push(partitionLabel(partition));
+      return { partition, pages: 0, swaps: 0, truncated: false, expired: true, oldestSeen: null };
+    }
+
+    throwIfAborted(signal);
+    const result = await forEachPage(
+      partition,
+      fromMs,
+      async (swaps) => collectRows(swaps),
+      signal,
+      undefined,
+      isExpired
+    );
+    if (result.expired) diagnostics.skippedPartitions.push(partitionLabel(partition));
+
+    console.log(
+      `[PARTITION] ${partitionLabel(partition)}: ${result.pages} page(s), ${result.swaps} swap(s), oldest ` +
+        `${result.oldestSeen ? new Date(result.oldestSeen).toISOString() : "n/a"}` +
+        `${result.truncated ? ", truncated at the offset cap" : ""}${
+          result.expired ? ", stopped at the time budget" : ""
+        }`
+    );
+    return result;
+  };
+
+  const ingestPartitions = async (partitions: Partition[]) => {
+    const { results, errors } = await PromisePool.withConcurrency(PARTITION_CONCURRENCY)
+      .for(partitions)
+      .process(ingestPartition);
+    // The pool collects failures rather than rejecting; an unread partition must fail the job
+    // instead of passing for a quiet day.
+    if (errors.length > 0) throw errors[0].raw ?? errors[0];
+    return results;
+  };
+
+  // Write whatever was read even if a partition fails: partial coverage beats none, and the
+  // checkpoint is held back either way.
+  const flush = async () => {
+    const rows = accumulator.drain();
+    if (rows.length === 0) return;
+    console.log(`Writing ${rows.length} Mayan rows.`);
+    await writeRows(rows);
+  };
+
+  let stillTruncated: string[] = [];
+  try {
+    const chainResults = await ingestPartitions(sourceChainNames.map((fromChain) => ({ fromChain })));
+
+    // A chain busy enough to exhaust the offset cap is split by service, which multiplies the depth a
+    // single query reaches. Rows the first pass already read are deduplicated by the accumulator.
+    const truncatedChains = chainResults
+      .filter(({ truncated }) => truncated)
+      .map(({ partition }) => partition.fromChain);
+    if (truncatedChains.length > 0) {
+      console.log(`Splitting ${truncatedChains.join(", ")} by service after hitting the offset cap.`);
+      // Split only by services the chain runs: querying a combination with no swaps is slow enough
+      // to exhaust its retries.
+      const serviceResults = await ingestPartitions(
+        truncatedChains.flatMap((fromChain) => servicesForChain(fromChain).map((service) => ({ fromChain, service })))
+      );
+      stillTruncated = serviceResults
+        .filter(({ truncated }) => truncated)
+        .map(({ partition }) => partitionLabel(partition));
+      if (stillTruncated.length > 0) {
+        console.warn(
+          `[WARN] ${stillTruncated.join(", ")} remain truncated after the service split; they cover only ` +
+            `back to the oldest page logged above.`
+        );
+      }
+    }
+  } finally {
+    await flush();
+  }
+
+  reportDiagnostics(diagnostics);
+
+  // Only a partition stopped by the time budget holds the checkpoint back, since only that one
+  // benefits from a retry; a truncated partition would stop at the same place every time.
+  if (diagnostics.skippedPartitions.length === 0) {
+    await saveCheckpoint(startedAt);
+  } else {
+    console.warn(`[WARN] Mayan checkpoint held back; the next run repeats from ${new Date(fromMs).toISOString()}.`);
+  }
+
+  const { volumeUsd, legs } = await getRecentVolumeUsd();
+  console.log(`Mayan ${VOLUME_WINDOW_MS / (60 * 60 * 1000)}h volume across ${legs} deposits: $${volumeUsd.toFixed(2)}`);
+  await setCache(VOLUME_CACHE_KEY, volumeUsd, null);
 };
 
 export default wrapScheduledLambda(handler);

--- a/src/utils/aggregate.ts
+++ b/src/utils/aggregate.ts
@@ -403,6 +403,7 @@ export const aggregateData = async (
           } else {
             let bnAmount = null;
             if (bridgeDbName === "mayan") {
+              // Mayan rows predating USD volume hold a human-readable amount, not base units.
               bnAmount = rawBnAmount;
             } else if (transformedDecimals) {
               bnAmount = rawBnAmount.dividedBy(10 ** Number(transformedDecimals));


### PR DESCRIPTION
## Summary

Replace the Mayan adapter's data source with Mayan's public explorer API. Each settled cross-chain swap is recorded as a deposit on the source chain and a withdrawal on the destination chain, both stored as USD volume.

## Why

The previous implementation read swaps from `dlapi.wormhole.com`, which requires a shared API key and no longer responds (Cloudflare 522), so Mayan ingestion has stopped. Mayan's own explorer API needs no credentials.

## Implementation

- Add a dedicated scheduled handler and drop the `MAYAN_API_KEY` dependency.
- Fetch from `explorer-api.mayan.finance/v3/swaps` with `format=raw`. The default response can report a source amount and a source price that refer to different tokens, which distorts source-side value.
- Derive settlement from the status and service the raw response carries in place of a completion flag.
- Walk the newest-first feed per source chain, splitting a chain by service if it exhausts the server's offset cap. Each chain lists the services it runs, so no query is issued for a combination that has no swaps.
- Resume from a checkpoint with a two-hour overlap, holding it back when a run stops early.
- Accumulate rows and upsert them keyed by swap, so swaps sharing one transaction are summed rather than overwritten.
- Retry rate limits, server errors and network failures with backoff.
- Fail on missing bridge configuration; report an unmapped chain id and skip its leg.

## Volume rules

- Value is taken from the destination side. Where the two sides disagree by more than an order of magnitude, the lower bound is used rather than an uncorroborated price.
- A swap priced only from the source side is capped, since nothing corroborates that price.
- Same-chain swaps are excluded. They are single-chain swaps rather than bridge transfers; this removes roughly 10% of previously reported volume.
- Legs below one cent are omitted, since aggregation discards zero-amount rows.
- EVM token addresses are lower-cased so token totals key consistently; Solana and Sui addresses are left untouched.

## Chains

Add Hyperliquid, covering HyperEVM and HyperCore. Aptos is retained for its existing config rows.

## Cutover behavior

With no checkpoint, the first run covers the last twelve hours, which is what the feed reliably pages back to on the busiest chains. Earlier gaps are not backfilled.

Rows written by the previous implementation are left in place. They place deposits on the destination chain, include same-chain swaps, and store mixed-case token addresses, so per-chain deposit and withdrawal figures change at the cutover.
